### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ libraryDependencies += "com.bot4s" %% "telegram-akka" % "4.0.0-RC2"
 
 For [mill](https://www.lihaoyi.com/mill/) add to your `build.sc` file:
 ```scala
-  def ivyDeps = Seq(
+  def ivyDeps = Agg(
     ivy"com.bot4s::telegram-core:4.0.0-RC2", // core
     ivy"com.bot4s::telegram-akka:4.0.0-RC2"  // extra goodies
   )


### PR DESCRIPTION
When I tried to run mill, i've got
```scala
build.sc:6: type mismatch;
 found   : Seq[mill.scalalib.Dep]
 required: mill.define.Target[mill.util.Loose.Agg[mill.scalalib.Dep]]
  def ivyDeps = Seq(
                   ^
build.sc:6: `T.command` definitions must have 1 parameter list
  def ivyDeps = Seq(
      ^
Compilation Failed
```
My changing fixes it.

Mill 0.2.7
Scala compiler version 2.12.7