### PR TITLE
Stateful chats 

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -122,7 +122,7 @@ abstract class TelegramBot4sCrossPlatform(val platformSegment: String, location:
 
 trait Publishable extends PublishModule {
 
-  override def publishVersion = "4.0.0-RC2"
+  override def publishVersion = "4.0.1.5"
 
   def pomSettings = PomSettings(
     description = "Telegram Bot API wrapper for Scala",

--- a/core/src/com/bot4s/telegram/api/RequestHandler.scala
+++ b/core/src/com/bot4s/telegram/api/RequestHandler.scala
@@ -34,7 +34,7 @@ abstract class RequestHandler[F[_]](implicit monadError: MonadError[F, Throwable
           case Right(response) =>
             monadError.pure(logger.trace("RESPONSE {} {}", uuid, response))
           case Left(e) =>
-            monadError.pure(logger.error(s"RESPONSE $uuid", e))
+            monadError.pure(logger.error(s"REQUEST $request WITH $uuid FAILED", e))
         })
         .rethrow
     } yield result

--- a/core/src/com/bot4s/telegram/api/declarative/Chats.scala
+++ b/core/src/com/bot4s/telegram/api/declarative/Chats.scala
@@ -1,0 +1,96 @@
+package com.bot4s.telegram.api.declarative
+
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import com.bot4s.telegram.methods.ParseMode.ParseMode
+import com.bot4s.telegram.methods.SendMessage
+import com.bot4s.telegram.models.{Message, MessageEntityType, ReplyMarkup}
+
+import java.util.concurrent.ConcurrentHashMap
+
+trait Deferred[F[_], A] {
+
+  def complete(a: A): F[Unit]
+
+  def get: F[A]
+}
+
+object Chats {
+  sealed trait ExitCase
+  case object Canceled extends ExitCase
+  case class Error(e: Throwable) extends ExitCase
+}
+
+import Chats._
+
+trait TelegramChat[F[_]] {
+
+  def write(
+    text: String,
+    parseMode: Option[ParseMode] = None,
+    disableWebPagePreview: Option[Boolean] = None,
+    disableNotification: Option[Boolean] = None,
+    replyToMessageId: Option[Int] = None,
+    replyMarkup: Option[ReplyMarkup] = None
+  ): F[Message]
+
+  def read(): F[Message]
+
+  def readCase(): F[Either[ExitCase, Message]]
+}
+
+trait Chats[F[_]] extends Messages[F] {
+
+  private val waitingQueue = new ConcurrentHashMap[Long, Deferred[F, Either[ExitCase, Message]]]()
+
+  def createChat(chatId: Long) =
+    new TelegramChat[F] {
+      override def write(
+        text: String,
+        parseMode: Option[ParseMode] = None,
+        disableWebPagePreview: Option[Boolean] = None,
+        disableNotification: Option[Boolean] = None,
+        replyToMessageId: Option[Int] = None,
+        replyMarkup: Option[ReplyMarkup] = None
+      ): F[Message] =
+        request(SendMessage(chatId, text, parseMode, disableWebPagePreview, disableNotification,
+          replyToMessageId, replyMarkup))
+
+      override def read(): F[Message] =
+        readCase().flatMap {
+          case Right(result) => monad.pure(result)
+          case Left(Canceled) => monad.raiseError(new Exception("canceled"))
+          case Left(Error(e)) => monad.raiseError(e)
+        }
+
+      override def readCase(): F[Either[ExitCase, Message]] =
+        for {
+          dfd <- makeDeferred[Either[ExitCase, Message]]
+          maybePrevDfd <- putDeferredInQueue(chatId, dfd)
+          _ <- maybePrevDfd.fold(monad.unit)(_.complete(Left(Canceled)))
+          result <- dfd.get
+        } yield result
+    }
+
+  def makeDeferred[A]: F[Deferred[F, A]]
+
+  def delay[A](thunk: => A): F[A]
+
+  override def receiveMessage(msg: Message): F[Unit] =
+    if (msg.entities.getOrElse(Seq.empty).exists(_.`type` == MessageEntityType.BotCommand)) {
+      super.receiveMessage(msg)
+    } else {
+      for {
+        maybeDfd <- extractFromQueue(msg.source)
+        _ <- maybeDfd.fold(monad.unit)(_.complete(Right(msg)))
+        _ <- super.receiveMessage(msg)
+      } yield ()
+    }
+
+  def putDeferredInQueue(chatId: Long, dfd: Deferred[F, Either[ExitCase, Message]]):
+      F[Option[Deferred[F, Either[ExitCase, Message]]]] =
+    delay(Option(waitingQueue.put(chatId, dfd)))
+
+  def extractFromQueue(chatId: Long): F[Option[Deferred[F, Either[ExitCase, Message]]]] =
+    delay(Option(waitingQueue.remove(chatId)))
+}

--- a/core/src/com/bot4s/telegram/future/Chats.scala
+++ b/core/src/com/bot4s/telegram/future/Chats.scala
@@ -1,0 +1,21 @@
+package com.bot4s.telegram.future
+
+import com.bot4s.telegram.api.declarative.{Deferred, Chats => BaseChats}
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+
+trait Chats extends BaseChats[Future] {
+
+  implicit val executionContext: ExecutionContext
+
+  override def makeDeferred[A]: Future[Deferred[Future, A]] =
+    Future {
+      val promise = Promise[A]()
+      new Deferred[Future, A] {
+        override def complete(a: A): Future[Unit] = Future { promise.success(a) }
+        override def get: Future[A] = promise.future
+      }
+    }
+
+  override def delay[A](thunk: => A) = Future { thunk }
+}

--- a/examples/src-cats/ChatBot.scala
+++ b/examples/src-cats/ChatBot.scala
@@ -1,0 +1,43 @@
+import cats.effect.Async
+import cats.effect.Concurrent
+import cats.effect.concurrent.Deferred
+import cats.effect.syntax.concurrent._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+import com.bot4s.telegram.api.declarative.Commands
+import com.bot4s.telegram.api.declarative.{Deferred => TelegramDeferred}
+import com.bot4s.telegram.api.declarative.Chats
+import com.bot4s.telegram.cats.Polling
+
+object ChatBot {
+
+  implicit def dfd2telegram[F[_], A](dfd: Deferred[F, A]): TelegramDeferred[F, A] = new TelegramDeferred[F, A] {
+    def complete(a: A) = dfd.complete(a)
+
+    def get: F[A] = dfd.get
+  }
+}
+
+class ChatBot[F[_]: Async: Concurrent](token: String) extends ExampleBot[F](token)
+    with Polling[F]
+    with Commands[F]
+    with Chats[F] {
+  import ChatBot._
+
+  override def delay[A](thunk: => A): F[A] = Async[F].delay(thunk)
+
+  override def makeDeferred[A] = Deferred[F, A].map(dfd2telegram)
+
+  onCommand("/hello") { implicit msg =>
+    val chat = createChat(msg.source)
+    (for {
+      _ <- chat.write("Enter parameter #1")
+      param1 <- chat.read()
+      _ <- chat.write("Enter parameter #2")
+      param2 <- chat.read()
+      _ <- chat.write(s"You just entered /hello ${param1.text} ${param2.text}")
+    } yield ()).start.void
+  }
+
+}

--- a/examples/src-cats/Launcher.scala
+++ b/examples/src-cats/Launcher.scala
@@ -10,6 +10,8 @@ object Launcher extends IOApp {
         new EchoBot[IO](token).startPolling.map(_ => ExitCode.Success)
       case List("CommandsBot", token) =>
         new CommandsBot[IO](token).startPolling.map(_ => ExitCode.Success)
+      case List("ChatBot", token) =>
+        new ChatBot[IO](token).startPolling.map(_ => ExitCode.Success)
       case List(name, _) =>
         IO.raiseError(new Exception(s"Unknown bot $name"))
       case _ =>

--- a/examples/src/ChatBot.scala
+++ b/examples/src/ChatBot.scala
@@ -1,0 +1,21 @@
+import com.bot4s.telegram.api.declarative.Commands
+import com.bot4s.telegram.future.{Polling, Chats}
+
+import scala.concurrent.Future
+
+class ChatBot(token: String) extends ExampleBot(token)
+  with Polling
+  with Commands[Future]
+  with Chats {
+
+  onCommand("/hello") { implicit msg =>
+    val chat = createChat(msg.source)
+    for {
+      _ <- chat.write("Enter parameter #1")
+      param1 <- chat.read()
+      _ <- chat.write("Enter parameter #2")
+      param2 <- chat.read()
+      _ <- chat.write(s"You just entered /hello ${param1.text} ${param2.text}")
+    } yield ()
+  }
+}


### PR DESCRIPTION
I would like to propose another enhancement which I implemented for my bot but maybe useful for your library.

Currently library has extractor `withArgs` which allows to enter commands like `/hello arg1 arg2`. Problem is that user needs to remember all arguments of command, order of these arguments.

I added new trait `Chats` to simplify entering commands with arguments.

```scala
  onCommand("/createuser") { implicit msg =>
    val chat = createChat(msg.source)
    for {
      _ <- chat.write("Enter login")
      login <- chat.read()
      _ <- chat.write("Enter password")
      password <- chat.read()
      _ <- chat.write("Enter username")
      username <- chat.read()
      // do some action based on these parameters
      _ <- chat.write(s"You just entered /createuser ${login.text} ${password.text} ${username.text}")
    } yield ()
  }
```

So when user enters command `/createuser`, we ask all necessary information sequentially. We can validate these parameters, ask re-enter them again and finally do some action.