### PR TITLE
Add missing SendAnimation request handler

### DIFF
--- a/core/src/com/bot4s/telegram/api/RequestHandler.scala
+++ b/core/src/com/bot4s/telegram/api/RequestHandler.scala
@@ -95,6 +95,7 @@ abstract class RequestHandler[F[_]](implicit monadError: MonadError[F, Throwable
       // Multipart requests
       case s: AddStickerToSet => sendRequest[R, AddStickerToSet](s)
       case s: CreateNewStickerSet => sendRequest[R, CreateNewStickerSet](s)
+      case s: SendAnimation => sendRequest[R, SendAnimation](s)
       case s: SendAudio => sendRequest[R, SendAudio](s)
       case s: SendDocument => sendRequest[R, SendDocument](s)
       case s: SendMediaGroup => sendRequest[R, SendMediaGroup](s)

--- a/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
@@ -292,6 +292,7 @@ trait CirceEncoders {
   // Multipart methods
   implicit val addStickerToSetEncoder : Encoder[AddStickerToSet] = deriveEncoder[AddStickerToSet]
   implicit val createNewStickerSetEncoder : Encoder[CreateNewStickerSet] = deriveEncoder[CreateNewStickerSet]
+  implicit val sendAnimationEncoder : Encoder[SendAnimation] = deriveEncoder[SendAnimation]
   implicit val sendAudioEncoder : Encoder[SendAudio] = deriveEncoder[SendAudio]
   implicit val sendDocumentEncoder : Encoder[SendDocument] = deriveEncoder[SendDocument]
   implicit val sendMediaGroupEncoder : Encoder[SendMediaGroup] = deriveEncoder[SendMediaGroup]

--- a/core/src/com/bot4s/telegram/methods/SendAnimation.scala
+++ b/core/src/com/bot4s/telegram/methods/SendAnimation.scala
@@ -28,7 +28,7 @@ case class SendAnimation(chatId              : ChatId,
                          caption             : Option[String] = None,
                          parseMode           : Option[ParseMode] = None,
                          disableNotification : Option[Boolean] = None,
-                         replyToMessageId    : Option[Int],
+                         replyToMessageId    : Option[Int] = None,
                          replyMarkup         : Option[ReplyMarkup] = None
                         ) extends MultipartRequest[Message] {
   override def getFiles: List[(String, InputFile)] = {


### PR DESCRIPTION
```
scala.MatchError: SendAnimation(Chat(****),FileId(***),None,None,None,None,None,None,None,None,None) (of class com.bot4s.telegram.methods.SendAnimation)
```

Also adding missing default `None` to `replyToMessageId    : Option[Int]`