### PR TITLE
[api] Add support for Quizzes using SendPoll

### DIFF
--- a/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
@@ -2,11 +2,11 @@ package com.bot4s.telegram.marshalling
 
 import java.util.NoSuchElementException
 
-import com.bot4s.telegram.methods.{ChatAction, ParseMode, Response}
 import com.bot4s.telegram.methods.ChatAction.ChatAction
 import com.bot4s.telegram.methods.ParseMode.ParseMode
+import com.bot4s.telegram.methods.PollType.PollType
 import com.bot4s.telegram.models._
-import com.bot4s.telegram.methods.{ChatAction, ParseMode}
+import com.bot4s.telegram.methods.{Response, ChatAction, ParseMode, PollType}
 import com.bot4s.telegram.models.ChatType.ChatType
 import com.bot4s.telegram.models.CountryCode.CountryCode
 import com.bot4s.telegram.models.Currency.Currency
@@ -18,6 +18,7 @@ import com.bot4s.telegram.models._
 import io.circe.Decoder
 import io.circe.generic.semiauto._
 import com.typesafe.scalalogging.StrictLogging
+import com.bot4s.telegram.methods
 
 /** Circe marshalling borrowed/inspired from [[https://github.com/nikdon/telepooz]]
   */
@@ -45,6 +46,9 @@ trait CirceDecoders extends StrictLogging {
 
   implicit val parseModeDecoder: Decoder[ParseMode] =
     Decoder[String].map(s => ParseMode.withName(pascalize(s)))
+
+  implicit val pollTypeDecoder: Decoder[PollType] =
+    Decoder[String].map(s => PollType.withName(pascalize(s)))
 
   implicit val countryCodeDecoder: Decoder[CountryCode] =
     Decoder[String].map(a => CountryCode.withName(a))

--- a/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
@@ -3,6 +3,7 @@ package com.bot4s.telegram.marshalling
 import com.bot4s.telegram.methods._
 import com.bot4s.telegram.methods.ChatAction.ChatAction
 import com.bot4s.telegram.methods.ParseMode.ParseMode
+import com.bot4s.telegram.methods.PollType.PollType
 import com.bot4s.telegram.models._
 import com.bot4s.telegram.methods._
 import com.bot4s.telegram.models.ChatType.ChatType
@@ -59,6 +60,9 @@ trait CirceEncoders {
 
   implicit val parseModeEncoder: Encoder[ParseMode] =
     Encoder[String].contramap[ParseMode](e => CaseConversions.snakenize(e.toString))
+
+  implicit val pollTypeEncoder: Encoder[PollType] =
+    Encoder[String].contramap[PollType](e => CaseConversions.snakenize(e.toString))
 
   implicit val photoSizeEncoder: Encoder[PhotoSize] = deriveConfiguredEncoder[PhotoSize]
 

--- a/core/src/com/bot4s/telegram/methods/PollType.scala
+++ b/core/src/com/bot4s/telegram/methods/PollType.scala
@@ -1,0 +1,10 @@
+package com.bot4s.telegram.methods
+
+/**
+  * Represent a type of poll
+  */
+object PollType extends Enumeration {
+  type PollType = Value
+  val regular = Value("regular")
+  val quiz = Value("quiz")
+}

--- a/core/src/com/bot4s/telegram/methods/SendPoll.scala
+++ b/core/src/com/bot4s/telegram/methods/SendPoll.scala
@@ -1,22 +1,46 @@
 package com.bot4s.telegram.methods
 
-import com.bot4s.telegram.models.{ChatId, Message, ReplyMarkup}
+import com.bot4s.telegram.models.{MessageEntity, ChatId, Message, ReplyMarkup}
+import com.bot4s.telegram.methods.ParseMode.ParseMode
+import com.bot4s.telegram.methods.PollType.PollType
 
 /**
   * Use this method to send a native poll.
   * A native poll can't be sent to a private chat. On success, the sent Message is returned.
   *
-  * @param chatId               Unique identifier for the target chat or username of the target channel (in the format @channelusername). A native poll can't be sent to a private chat.
-  * @param question             Poll question, 1-255 characters
-  * @param options              List of answer options, 2-10 strings 1-100 characters each
-  * @param disableNotification  Sends the message silently. Users will receive a notification with no sound.
-  * @param replyToMessageId     If the message is a reply, ID of the original message
-  * @param replyMarkup          Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  * @param chatId                     Unique identifier for the target chat or username of the target channel (in the format @channelusername). A native poll can't be sent to a private chat.
+  * @param question                   Poll question, 1-255 characters
+  * @param options                    List of answer options, 2-10 strings 1-100 characters each
+  * @param isAnonymous                Optional: if the poll needs to be anonymous, defaults to True
+  * @param type                       Optional: Poll type, “quiz” or “regular”, defaults to “regular”
+  * @param allowsMultipleAnswers      Optional: True, if the poll allows multiple answers, ignored for polls in quiz mode, defaults to False
+  * @param correctOptionId            Optional: 0-based identifier of the correct answer option, required for polls in quiz mode
+  * @param explanation                Optional: Text that is shown when a user chooses an incorrect answer or taps on the lamp icon in a quiz-style poll, 0-200 characters with at most 2 line feeds after entities parsing
+  * @param explanationParseMode       Optional: String Optional Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+  * @param explanationEntities        Optional: List of special entities that appear in the poll explanation, which can be specified instead of parse_mode
+  * @param openPeriod                 Optional: Amount of time in seconds the poll will be active after creation, 5-600. Can't be used together with close_date.
+  * @param closeDate                  Optional: Point in time (Unix timestamp) when the poll will be automatically closed. Must be at least 5 and no more than 600 seconds in the future. Can't be used together with open_period.
+  * @param isClosed                   Optional: Pass True, if the poll needs to be immediately closed. This can be useful for poll preview.
+  * @param disableNotification        Sends the message silently. Users will receive a notification with no sound.
+  * @param replyToMessageId           If the message is a reply, ID of the original message
+  * @param allowSendingWithoutReply   Optional: Pass True, if the message should be sent even if the specified replied-to message is not found
+  * @param replyMarkup                Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
   */
-case class SendPoll(chatId              : ChatId,
-                    question            : String,
-                    options             : Array[String],
-                    disableNotification : Option[Boolean] = None,
-                    replyToMessageId    : Option[Int] = None,
-                    replyMarkup         : Option[ReplyMarkup] = None
+case class SendPoll(chatId                   : ChatId,
+                    question                 : String,
+                    options                  : Array[String],
+                    isAnonymous              : Option[Boolean]              = None,
+                    `type`                   : Option[PollType]             = None,
+                    allowsMultipleAnswers    : Option[Boolean]              = None,
+                    correctOptionId          : Option[Int]                  = None,
+                    explanation              : Option[String]               = None,
+                    explanationParseMode     : Option[ParseMode]            = None,
+                    explanationEntities      : Option[Array[MessageEntity]] = None,
+                    openPeriod               : Option[Int]                  = None,
+                    closeDate                : Option[Int]                  = None,
+                    isClosed                 : Option[Boolean]              = None,
+                    disableNotification      : Option[Boolean]              = None,
+                    replyToMessageId         : Option[Int]                  = None,
+                    allowSendingWithoutReply : Option[Boolean]              = None,
+                    replyMarkup              : Option[ReplyMarkup]          = None
                    ) extends JsonRequest[Message]

--- a/core/src/com/bot4s/telegram/models/PhotoSize.scala
+++ b/core/src/com/bot4s/telegram/models/PhotoSize.scala
@@ -2,14 +2,16 @@ package com.bot4s.telegram.models
 
 /** This object represents one size of a photo or a file / sticker thumbnail.
   *
-  * @param fileId    Unique identifier for this file
-  * @param width     Photo width
-  * @param height    Photo height
-  * @param fileSize  Optional File size
+  * @param fileId       Unique identifier for this file, which can be used to download or reuse the file
+  * @param fileUniqueId Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+  * @param width        Photo width
+  * @param height       Photo height
+  * @param fileSize     Optional File size
   */
 case class PhotoSize(
-                      fileId   : String,
-                      width    : Int,
-                      height   : Int,
-                      fileSize : Option[Int] = None
+                      fileId        : String,
+                      fileUniqueId  : String,
+                      width         : Int,
+                      height        : Int,
+                      fileSize      : Option[Int] = None
                     )

--- a/examples/src/PollBot.scala
+++ b/examples/src/PollBot.scala
@@ -1,5 +1,3 @@
-import java.util.concurrent.TimeUnit
-
 import cats.instances.future._
 import cats.syntax.functor._
 import com.bot4s.telegram.Implicits._
@@ -8,7 +6,7 @@ import com.bot4s.telegram.future.Polling
 import com.bot4s.telegram.methods._
 import com.bot4s.telegram.models._
 
-import scala.concurrent.{Await, Future}
+import scala.concurrent.Future
 import scala.util.Failure
 
 /**
@@ -22,8 +20,8 @@ class PollBot(token: String) extends ExampleBot(token)
 
   var pollMsgId = 0
 
-  onCommand("poll") { implicit msg =>
-    val f = request(SendPoll(ChatId(msg.chat.id), "Pick A or B", Array("A", "B")))
+  def sendPoll(poll: SendPoll) = {
+    val f = request(poll)
     f.onComplete {
       case Failure(e) => println("Error " + e)
       case _ =>
@@ -34,6 +32,24 @@ class PollBot(token: String) extends ExampleBot(token)
       println("Poll sent")
       pollMsgId = poll.messageId
     }
+  }
+
+  onCommand("poll") { implicit msg =>
+    val f = SendPoll(ChatId(msg.chat.id), "Pick A or B", Array("A", "B"))
+    sendPoll(f)
+  }
+
+  onCommand("quizPoll") { implicit msg => 
+    val f = SendPoll(
+      chatId = ChatId(msg.chat.id),
+      question =  "Pick A or B",
+      options = Array("A", "B"),
+      `type`  = PollType.quiz,
+      correctOptionId = Some(0),
+      explanation = "The correct answer was A",
+      explanationParseMode = ParseMode.Markdown
+    )
+    sendPoll(f)
   }
 
   onCommand("stop") { implicit msg =>


### PR DESCRIPTION
The SendPoll API can be used to send quizzes on telegram.
A missing additional field `fileUniqueId` was added on the `PhotoSize`
object.

Please refer to `PollBot.scala` for a simple usage of the quiz API.

Fixes #90
Fixes #89 