### PR TITLE
[api][markdown] Add MarkdownV2 format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ credentials.*
 *.swp
 *.swn
 *.swo
+
+#dev specific (swagger experiments)
+extractors/

--- a/core/src/com/bot4s/telegram/api/declarative/Messages.scala
+++ b/core/src/com/bot4s/telegram/api/declarative/Messages.scala
@@ -81,7 +81,7 @@ trait Messages[F[_]] extends BotBase[F] {
   }
 
   /**
-    * Sends text replies in Markdown format.
+    * Sends text replies in Markdown format (using legacy format)
  *
  * @param text                     Text of the message to be sent
     * @param disableWebPagePreview Optional Disables link previews for links in this message
@@ -103,6 +103,36 @@ trait Messages[F[_]] extends BotBase[F] {
     reply(
       text,
       Some(ParseMode.Markdown),
+      disableWebPagePreview,
+      disableNotification,
+      replyToMessageId,
+      replyMarkup
+    )(message)
+  }
+
+  /**
+    * Sends text replies in Markdown format (using the new format)
+ *
+ * @param text                     Text of the message to be sent
+    * @param disableWebPagePreview Optional Disables link previews for links in this message
+    * @param disableNotification   Optional Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+    * @param replyToMessageId      Optional If the message is a reply, ID of the original message
+    * @param replyMarkup           [[models.InlineKeyboardMarkup]] or
+    *                              [[models.ReplyKeyboardMarkup]] or
+    *                              [[ReplyKeyboardRemove]] or
+    *                              [[ForceReply]]
+    *                              Optional Additional interface options.
+    *                              A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to hide reply keyboard or to force a reply from the user.
+    */
+  def replyMdV2(text                  : String,
+            disableWebPagePreview : Option[Boolean] = None,
+            disableNotification   : Option[Boolean] = None,
+            replyToMessageId      : Option[Int] = None,
+            replyMarkup           : Option[ReplyMarkup] = None)
+           (implicit message: Message): F[Message] = {
+    reply(
+      text,
+      Some(ParseMode.MarkdownV2),
       disableWebPagePreview,
       disableNotification,
       replyToMessageId,

--- a/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
@@ -221,7 +221,7 @@ trait CirceEncoders {
 
  
   // Ignore InputFiles as JSON.
-  implicit def inputFileEncoder: Encoder[InputFile] = Encoder.instance(_ ⇒ io.circe.Json.Null)
+  implicit def inputFileEncoder: Encoder[InputFile] = Encoder.instance(_ => io.circe.Json.Null)
 
   implicit val sendLocationEncoder: Encoder[SendLocation] = deriveConfiguredEncoder[SendLocation]
   implicit val sendVenueEncoder: Encoder[SendVenue] = deriveConfiguredEncoder[SendVenue]

--- a/core/src/com/bot4s/telegram/methods/ParseMode.scala
+++ b/core/src/com/bot4s/telegram/methods/ParseMode.scala
@@ -13,6 +13,24 @@ package com.bot4s.telegram.methods
   *   [text](URL)
   *   `inline fixed-width code`
   *   ```pre-formatted fixed-width code block```
+  * 
+  * MarkdownV2 style (https://core.telegram.org/bots/api#markdownv2-style)
+  *   To use this mode, pass MarkdownV2 in the parse_mode field. Use the following syntax in your message:
+  * 
+  *   *bold \*text*
+  *   _italic \*text_
+  *   __underline__
+  *   ~strikethrough~
+  *   *bold _italic bold ~italic bold strikethrough~ __underline italic bold___ bold*
+  *   [inline URL](https://github.com/bot4s/telegram/)
+  *   [inline mention of a user](tg://user?id=123456789)
+  *   `inline fixed-width code`
+  *   ```
+  *   pre-formatted fixed-width code block
+  *   ```
+  *   ```python
+  *   pre-formatted fixed-width code block written in the Python programming language
+  *   ```
   *
   * HTML style
   *   To use this mode, pass HTML in the parse_mode field when using sendMessage. The following tags are currently supported:
@@ -32,5 +50,6 @@ package com.bot4s.telegram.methods
 object ParseMode extends Enumeration {
   type ParseMode = Value
   val Markdown = Value("Markdown")
+  val MarkdownV2 = Value("markdownv2")
   val HTML = Value("HTML")
 }

--- a/examples/src/MarkdownBot.scala
+++ b/examples/src/MarkdownBot.scala
@@ -1,0 +1,61 @@
+import cats.instances.future._
+import cats.syntax.functor._
+import com.bot4s.telegram.future.Polling
+import com.bot4s.telegram.methods._
+
+import scala.concurrent.Future
+import com.bot4s.telegram.api.declarative.Commands
+
+class MarkdownBot(token: String) extends ExampleBot(token)
+  with Polling 
+  with Commands[Future] {
+
+  onCommand("markdownV2") { implicit msg => 
+    reply("""
+    *MardownV2*
+*bold \*text*
+_italic \*text_
+__underline__
+~strikethrough~
+*bold _italic bold ~italic bold strikethrough~ __underline italic bold___ bold*
+[inline URL](http://www.bot4s.com/)
+[inline mention of a user](tg://user?id=123456789)
+`inline fixed-width code`
+```
+pre-formatted fixed-width code block
+```
+```python
+pre-formatted fixed-width code block written in the Python programming language
+```
+    """, Some(ParseMode.MarkdownV2)).void
+  }
+  onCommand("markdown") { implicit msg =>  reply("""
+  *Mardown parsing*
+  *bold text*
+_italic text_
+[inline URL](http://www.bot4s.com/)
+[inline mention of a user](tg://user?id=123456789)
+`inline fixed-width code`
+```
+pre-formatted fixed-width code block
+```
+```python
+pre-formatted fixed-width code block written in the Python programming language
+```
+  """, Some(ParseMode.Markdown)).void
+  }
+  onCommand("html") { implicit msg => reply("""
+  <b>HTML Parser</b>
+  <b>bold</b>, <strong>bold</strong>
+<i>italic</i>, <em>italic</em>
+<u>underline</u>, <ins>underline</ins>
+<s>strikethrough</s>, <strike>strikethrough</strike>, <del>strikethrough</del>
+<b>bold <i>italic bold <s>italic bold strikethrough</s> <u>underline italic bold</u></i> bold</b>
+<a href="http://www.bot4s.com/">inline URL</a>
+<a href="tg://user?id=123456789">inline mention of a user</a>
+<code>inline fixed-width code</code>
+<pre>pre-formatted fixed-width code block</pre>
+<pre><code class="language-python">pre-formatted fixed-width code block written in the Python programming language</code></pre>
+  """, Some(ParseMode.HTML)).void
+  }
+}


### PR DESCRIPTION
Telegram release a new version of the markdown mode.
This was documented https://core.telegram.org/bots/api#markdownv2-style
It allows nested style and is more powerful than the first version.

There are a few rules to respect in order to use the new markdown style:
```
-  Any character with code between 1 and 126 inclusively can be escaped anywhere with a preceding '\' character, in which case it is treated as an ordinary character and not a part of the markup.
-  Inside pre and code entities, all '`' and '\' characters must be escaped with a preceding '\' character.
-  Inside (...) part of inline link definition, all ')' and '\' must be escaped with a preceding '\' character.
-  In all other places characters '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!' must be escaped with the preceding character '\'.
-  In case of ambiguity between italic and underline entities __ is always greadily treated from left to right as beginning or end of underline entity, so instead of ___italic underline___ use ___italic underline_\r__, where \r is a character with code 13, which will be ignored.
```

Warning: the case in `markdownv2` seems to be important. When using the documented `MarkdownV2` string as described in the doc, the bot was failing with a `Bad Request: unsupported parse_mode` error.

Fixes #85 