### PR TITLE
Don't break the effect on exceptions

### DIFF
--- a/core/src/com/bot4s/telegram/clients/SttpClient.scala
+++ b/core/src/com/bot4s/telegram/clients/SttpClient.scala
@@ -77,8 +77,6 @@ class SttpClient[F[_]](token: String, telegramHost: String = "api.telegram.org")
       .response(asJson[Response[R]])
       .send[F]()
 
-    response
-      .map(_.unsafeBody)
-      .flatMap(t => monadError.fromTry(Try(processApiResponse[R](t))))
+    monadError.flatMap(monadError.map(response)(_.unsafeBody))(t => monadError.fromTry(Try(processApiResponse[R](t))))
   }
 }

--- a/core/src/com/bot4s/telegram/clients/SttpClient.scala
+++ b/core/src/com/bot4s/telegram/clients/SttpClient.scala
@@ -13,6 +13,7 @@ import io.circe.parser.parse
 import io.circe.{Decoder, Encoder}
 import com.typesafe.scalalogging.StrictLogging
 
+import scala.util.Try
 import scala.concurrent.duration._
 
 /** Sttp HTTP client.

--- a/core/src/com/bot4s/telegram/clients/SttpClient.scala
+++ b/core/src/com/bot4s/telegram/clients/SttpClient.scala
@@ -78,6 +78,6 @@ class SttpClient[F[_]](token: String, telegramHost: String = "api.telegram.org")
 
     response
       .map(_.unsafeBody)
-      .map(processApiResponse[R])
+      .flatMap(t => monadError.fromTry(Try(processApiResponse[R](t))))
   }
 }


### PR DESCRIPTION
Currently, the processApiResponse call throws an exception (when an unexpected response is returned) which will kill the effect handling mechanism without the possibility to recover. This fix should fix that.