### PR TITLE
[scala][api] Remove support for Symbols

### DIFF
--- a/core/src/com/bot4s/telegram/api/declarative/Commands.scala
+++ b/core/src/com/bot4s/telegram/api/declarative/Commands.scala
@@ -19,8 +19,6 @@ trait Commands[F[_]] extends Messages[F] with CommandImplicits {
     * @example {{{
     *   onCommand("/command") { implicit msg => ... }
     *   onCommand("command") { implicit msg => ... }
-    *   onCommand('echo) { implicit msg => ... }
-    *   onCommand('hi | 'hello | 'hey) { implicit msg => ... }
     *   onCommand("/adieu" | "/bye") { implicit msg => ... }
     *   onCommand(cmd => cmd.cmd.contains("help")) { implicit msg => ... }
     * }}}
@@ -42,7 +40,7 @@ trait Commands[F[_]] extends Messages[F] with CommandImplicits {
     * The first token, the /command, is dropped.
     *
     * @example {{{
-    *   on('echo) { implicit msg =>
+    *   on("echo") { implicit msg =>
     *     withArgs { args =>
     *       reply(args.mkString(" "))
     *     }

--- a/core/src/com/bot4s/telegram/api/declarative/Commands.scala
+++ b/core/src/com/bot4s/telegram/api/declarative/Commands.scala
@@ -112,10 +112,6 @@ trait CommandImplicits {
       case Command(cmd, _) if target.equalsIgnoreCase(cmd) => true
     }
   }
-
-  implicit def symbolToCommandFilter(s: Symbol) = {
-    stringToCommandFilter(s.name)
-  }
 }
 
 object CommandFilterMagnet {

--- a/core/test/src/com/bot4s/telegram/api/CommandsSuite.scala
+++ b/core/test/src/com/bot4s/telegram/api/CommandsSuite.scala
@@ -68,22 +68,6 @@ class CommandsSuite extends AnyFlatSpec with MockFactory with TestUtils with Com
     } yield ()).get
   }
 
-  it should "match Symbol command" in new Fixture {
-    handler.expects(*).returning(Future.successful(())).once()
-    bot.onCommand('cmd)(handler)
-    bot.receiveExtMessage((textMessage("/cmd"), None)).get
-  }
-
-  it should "match Symbol command sequence" in new Fixture {
-    handler.expects(*).returning(Future.successful(())).twice()
-    bot.onCommand('a | 'b)(handler)
-    (for {
-      _ <- bot.receiveExtMessage((textMessage("/a"), None))
-      _ <- bot.receiveExtMessage((textMessage("/b"), None))
-      _ <- bot.receiveExtMessage((textMessage("/c"), None))
-    } yield ()).get
-  }
-
   it should "support @sender suffix" in new Fixture {
     val m = textMessage("  /hello@Test_Bot  ")
     handlerHello.expects(m).returning(Future.successful(())).once()

--- a/examples/src-cats/CommandsBot.scala
+++ b/examples/src-cats/CommandsBot.scala
@@ -56,7 +56,7 @@ class CommandsBot[F[_]: Async: Timer : ContextShift](token: String) extends Exam
   }
 
   // withArgs extracts command arguments.
-  onCommand('echo) { implicit msg =>
+  onCommand("echo") { implicit msg =>
     withArgs {
       args =>
         reply(args.mkString(" ")).void

--- a/examples/src-jvm/LmgtfyBot.scala
+++ b/examples/src-jvm/LmgtfyBot.scala
@@ -21,7 +21,7 @@ class LmgtfyBot(token: String) extends ExampleBot(token)
   def lmgtfyBtn(query: String): InlineKeyboardMarkup = InlineKeyboardMarkup.singleButton(
     InlineKeyboardButton.url("\uD83C\uDDECoogle it now!", lmgtfyUrl(query)))
 
-  onCommand('start | 'help) { implicit msg =>
+  onCommand("start" | "help") { implicit msg =>
     reply(
       s"""Generates ${"Let me \uD83C\uDDECoogle that for you!".italic} links.
          |
@@ -36,7 +36,7 @@ class LmgtfyBot(token: String) extends ExampleBot(token)
       parseMode = ParseMode.Markdown).void
   }
 
-  onCommand('lmgtfy) { implicit msg =>
+  onCommand("lmgtfy") { implicit msg =>
     withArgs { args =>
       val query = args.mkString(" ")
 
@@ -52,7 +52,7 @@ class LmgtfyBot(token: String) extends ExampleBot(token)
       .withQuery(Query("q" -> query))
       .toString()
 
-  onCommand('btn | 'lmgtfy2) { implicit msg =>
+  onCommand("btn" | "lmgtfy2") { implicit msg =>
     withArgs { args =>
       val query = args.mkString(" ")
       reply(query, replyMarkup = lmgtfyBtn(query)).void

--- a/examples/src-jvm/ProxyBot.scala
+++ b/examples/src-jvm/ProxyBot.scala
@@ -22,7 +22,7 @@ class ProxyBot(token: String) extends ExampleBot(token)
 
   override val client = new ScalajHttpClient(token, proxy)
 
-  onCommand('hello) { implicit msg =>
+  onCommand("hello") { implicit msg =>
     reply("Hi " + msg.from.fold("Mr. X")(_.firstName)).void
   }
 }

--- a/examples/src-jvm/QrCodesBot.scala
+++ b/examples/src-jvm/QrCodesBot.scala
@@ -21,7 +21,7 @@ class QrCodesBot(token: String) extends AkkaExampleBot(token)
   with ChatActions[Future] {
 
   // Multiple variants
-  onCommand('qr | 'qrcode | 'qr_code) { implicit msg =>
+  onCommand("qr" | "qrcode" | "qr_code") { implicit msg =>
     withArgs { args =>
       val url = "https://api.qrserver.com/v1/create-qr-code/?data=" +
         URLEncoder.encode(args mkString " ", "UTF-8")

--- a/examples/src/AuthenticationBot.scala
+++ b/examples/src/AuthenticationBot.scala
@@ -53,7 +53,7 @@ class AuthenticationBot(token: String) extends ExampleBot(token)
   with Commands[Future]
   with SillyAuthentication {
 
-  onCommand('start | 'help) { implicit msg =>
+  onCommand("start" | "help") { implicit msg =>
     reply(
       """Authentication:
         |/login - Login

--- a/examples/src/CommandsBot.scala
+++ b/examples/src/CommandsBot.scala
@@ -45,12 +45,12 @@ class CommandsBot(token: String) extends ExampleBot(token)
   }
 
   // Also using Symbols; the "/" prefix is added by default.
-  onCommand('привет) { implicit msg =>
+  onCommand("привет") { implicit msg =>
     reply("\uD83C\uDDF7\uD83C\uDDFA").void
   }
 
   // Note that non-ascii commands are not clickable.
-  onCommand('こんにちは | '你好 | '안녕하세요) { implicit msg =>
+  onCommand("こんにちは" | "你好" | "안녕하세요") { implicit msg =>
     reply("Hello from Asia?").void
   }
 
@@ -65,7 +65,7 @@ class CommandsBot(token: String) extends ExampleBot(token)
   }
 
   // withArgs extracts command arguments.
-  onCommand('echo) { implicit msg =>
+  onCommand("echo") { implicit msg =>
     withArgs {
       args =>
         reply(args.mkString(" ")).void

--- a/examples/src/PokerBot.scala
+++ b/examples/src/PokerBot.scala
@@ -56,11 +56,11 @@ class PokerBot(token: String) extends ExampleBot(token)
   }
 
 
-  onCommand('trivia) { implicit msg =>
+  onCommand("trivia") { implicit msg =>
     replyWithGame("trivia_game").void
   }
 
-  onCommand('tictactoe | 'xoxo) { implicit msg =>
+  onCommand("tictactoe" | "xoxo") { implicit msg =>
     replyWithGame("tictactoe_game").void
   }
 }

--- a/examples/src/ProcessBot.scala
+++ b/examples/src/ProcessBot.scala
@@ -13,7 +13,7 @@ class ProcessBot(token: String) extends ExampleBot(token)
   with Polling
   with Commands[Future] {
 
-  onCommand('run | 'exec | 'execute | 'cmd) { implicit msg =>
+  onCommand("run" | "exec" | "execute" | "cmd") { implicit msg =>
     withArgs {
       args =>
         try {

--- a/examples/src/RandomBot.scala
+++ b/examples/src/RandomBot.scala
@@ -16,7 +16,7 @@ class RandomBot(token: String) extends ExampleBot(token)
   onCommand("coin" or "flip") { implicit msg =>
     reply(if (rng.nextBoolean()) "Head!" else "Tail!").void
   }
-  onCommand('real | 'double | 'float) { implicit msg =>
+  onCommand("real" | "double" | "float") { implicit msg =>
     reply(rng.nextDouble().toString).void
   }
   onCommand("/die" | "roll") { implicit msg =>
@@ -29,7 +29,7 @@ class RandomBot(token: String) extends ExampleBot(token)
       case _ => reply("Invalid argumentヽ(ಠ_ಠ)ノ").void
     }
   }
-  onCommand('choose | 'pick | 'select) { implicit msg =>
+  onCommand("choose" | "pick" | "select") { implicit msg =>
     withArgs { args =>
       replyMd(if (args.isEmpty) "No arguments provided." else args(rng.nextInt(args.size))).void
     }


### PR DESCRIPTION
Scala deprecated the support for Symbols (in 2.13) and they will we removed in next versions.
This introduces a breaking changes, without deprecation warning for the bot using Symbol as input.

Fixes #105 