### PR TITLE
[deps] Upgrade to STTP3

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -11,8 +11,7 @@ object library {
     val circe              = "0.13.0"
     val cats               = "2.1.1"
     val catsEffect         = "2.3.1"
-    val rosHttp            = "3.0.0" // Note: This is no longer maintained
-    val sttp               = "1.7.2" // TODO: migrate to 2.x
+    val sttp               = "3.2.3"
     val scalaTest          = "3.2.2"
     val scalaMockScalaTest = "5.1.0"
     val scalaLogging       = "3.9.2"
@@ -33,8 +32,8 @@ object library {
   val akkaTestkit        = ivy"com.typesafe.akka::akka-testkit::${Version.akkaTestkit}"
   val akkaActor          = ivy"com.typesafe.akka::akka-actor::${Version.akkaActor}"
   val akkaStream         = ivy"com.typesafe.akka::akka-stream::${Version.akkaStream}"
-  val asyncHttpClientBackendCats = ivy"com.softwaremill.sttp::async-http-client-backend-cats::${Version.sttp}"
-  val asyncHttpClientBackendMonix = ivy"com.softwaremill.sttp::async-http-client-backend-monix::${Version.sttp}"
+  val asyncHttpClientBackendCats = ivy"com.softwaremill.sttp.client3::async-http-client-backend-cats::${Version.sttp}"
+  val asyncHttpClientBackendMonix = ivy"com.softwaremill.sttp.client3::async-http-client-backend-monix::${Version.sttp}"
   val scalajHttp         = ivy"org.scalaj::scalaj-http::${Version.scalajHttp}"
   val scalaLogging       = ivy"com.typesafe.scala-logging::scala-logging::${Version.scalaLogging}"
   val scalaMockScalaTest = ivy"org.scalamock::scalamock::${Version.scalaMockScalaTest}"
@@ -50,10 +49,9 @@ object library {
   val catsFree           = ivy"org.typelevel::cats-free::${Version.cats}"
   val catsEffect         = ivy"org.typelevel::cats-effect::${Version.catsEffect}"
   val monix              = ivy"io.monix::monix::${Version.monix}"
-  val rosHttp            = ivy"fr.hmil::roshttp::${Version.rosHttp}"
-  val sttpCore           = ivy"com.softwaremill.sttp::core::${Version.sttp}"
-  val sttpCirce          = ivy"com.softwaremill.sttp::circe::${Version.sttp}"
-  val sttpOkHttp         = ivy"com.softwaremill.sttp::okhttp-backend::${Version.sttp}"
+  val sttpCore           = ivy"com.softwaremill.sttp.client3::core::${Version.sttp}"
+  val sttpCirce          = ivy"com.softwaremill.sttp.client3::circe::${Version.sttp}"
+  val sttpOkHttp         = ivy"com.softwaremill.sttp.client3::okhttp-backend::${Version.sttp}"
   val hammock            = ivy"com.pepegar::hammock-core::${Version.hammock}"
 }
 

--- a/core/src/com/bot4s/telegram/cats/TelegramBot.scala
+++ b/core/src/com/bot4s/telegram/cats/TelegramBot.scala
@@ -3,11 +3,11 @@ package com.bot4s.telegram.cats
 import cats.MonadError
 import com.bot4s.telegram.api.BotBase
 import com.bot4s.telegram.clients.SttpClient
-import com.softwaremill.sttp.SttpBackend
+import sttp.client3.SttpBackend
 
 class TelegramBot[F[_]] (
   token: String,
-  backend: SttpBackend[F, Nothing],
+  backend: SttpBackend[F, Any],
   telegramHost: String = "api.telegram.org"
 )(implicit monadError: MonadError[F, Throwable]) extends BotBase[F] {
 

--- a/core/src/com/bot4s/telegram/clients/FutureSttpClient.scala
+++ b/core/src/com/bot4s/telegram/clients/FutureSttpClient.scala
@@ -1,11 +1,11 @@
 package com.bot4s.telegram.clients
 
 import cats.instances.future._
-import com.softwaremill.sttp.SttpBackend
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import sttp.client3.SttpBackend
 
 class FutureSttpClient(token: String, telegramHost: String = "api.telegram.org")
-  (implicit backend: SttpBackend[Future, Nothing], ec: ExecutionContext)
+  (implicit backend: SttpBackend[Future, Any], ec: ExecutionContext)
   extends SttpClient[Future](token, telegramHost)

--- a/core/test/src/com/bot4s/telegram/clients/SttpClientSuite.scala
+++ b/core/test/src/com/bot4s/telegram/clients/SttpClientSuite.scala
@@ -4,21 +4,36 @@ import org.scalatest.flatspec.AsyncFlatSpec
 import sttp.client3.testing.SttpBackendStub
 import com.bot4s.telegram.methods.GetMe
 import scala.concurrent.ExecutionContext
+import io.circe.ParsingFailure
+import com.bot4s.telegram.api.TelegramApiException
 
 
 class SttpClientSuite extends AsyncFlatSpec {
 
   behavior of "STTP client"
 
-  it should "correctly extract the result in sendRequest" in {
+  it should "fail with a ParsingFailure in case of server error" in {
       val backend = SttpBackendStub
         .asynchronousFuture
         .whenRequestMatches(_.uri.path.contains("GetMe"))
         .thenRespondServerError()
       val client = new FutureSttpClient("")(backend, implicitly[ExecutionContext])
 
-      recoverToSucceededIf[Exception] {
+      recoverToSucceededIf[ParsingFailure] {
         client.apply(GetMe)
       }
+  }
+
+  it should "fail with a TelegramApiException the API returned an error" in {
+      val backend = SttpBackendStub
+        .asynchronousFuture
+        .whenRequestMatches(_.uri.path.contains("GetMe"))
+        .thenRespond("""{"ok":false,"error_code":401,"description":"Unauthorized"}""")
+      val client = new FutureSttpClient("")(backend, implicitly[ExecutionContext])
+
+      recoverToSucceededIf[TelegramApiException] {
+        client.apply(GetMe)
+      }
+
   }
 }

--- a/core/test/src/com/bot4s/telegram/clients/SttpClientSuite.scala
+++ b/core/test/src/com/bot4s/telegram/clients/SttpClientSuite.scala
@@ -1,0 +1,24 @@
+package com.bot4s.telegram.clients
+
+import org.scalatest.flatspec.AsyncFlatSpec
+import sttp.client3.testing.SttpBackendStub
+import com.bot4s.telegram.methods.GetMe
+import scala.concurrent.ExecutionContext
+
+
+class SttpClientSuite extends AsyncFlatSpec {
+
+  behavior of "STTP client"
+
+  it should "correctly extract the result in sendRequest" in {
+      val backend = SttpBackendStub
+        .asynchronousFuture
+        .whenRequestMatches(_.uri.path.contains("GetMe"))
+        .thenRespondServerError()
+      val client = new FutureSttpClient("")(backend, implicitly[ExecutionContext])
+
+      recoverToSucceededIf[Exception] {
+        client.apply(GetMe)
+      }
+  }
+}

--- a/examples/src-cats/CommandsBot.scala
+++ b/examples/src-cats/CommandsBot.scala
@@ -1,4 +1,4 @@
-import cats.effect.{Async, ContextShift}
+import cats.effect.{Concurrent, ContextShift}
 import cats.effect.Timer
 import cats.syntax.flatMap._
 import cats.syntax.functor._
@@ -17,7 +17,7 @@ import scala.util.Try
   *
   * @param token Bot's token.
   */
-class CommandsBot[F[_]: Async: Timer : ContextShift](token: String) extends ExampleBot[F](token)
+class CommandsBot[F[_]: Concurrent: Timer : ContextShift](token: String) extends ExampleBot[F](token)
   with Polling[F]
   with Commands[F]
   with RegexCommands[F] {

--- a/examples/src-cats/EchoBot.scala
+++ b/examples/src-cats/EchoBot.scala
@@ -1,11 +1,11 @@
-import cats.effect.{Async, ContextShift}
+import cats.effect.{Concurrent, ContextShift}
 import cats.syntax.functor._
 
 import com.bot4s.telegram.cats.Polling
 import com.bot4s.telegram.methods._
 import com.bot4s.telegram.models._
 
-class EchoBot[F[_]: Async : ContextShift](token: String) extends ExampleBot[F](token) with Polling[F] {
+class EchoBot[F[_]: Concurrent : ContextShift](token: String) extends ExampleBot[F](token) with Polling[F] {
 
   override def receiveMessage(msg: Message): F[Unit] =
     msg.text.fold(unit) { text =>

--- a/examples/src-cats/ExampleBot.scala
+++ b/examples/src-cats/ExampleBot.scala
@@ -1,6 +1,7 @@
-import cats.effect.{Async, ContextShift}
+import cats.effect.{ContextShift, Concurrent}
 import com.bot4s.telegram.cats.TelegramBot
-import com.softwaremill.sttp.asynchttpclient.cats.AsyncHttpClientCatsBackend
+import org.asynchttpclient.Dsl.asyncHttpClient
+import sttp.client3.asynchttpclient.cats.AsyncHttpClientCatsBackend
 
-abstract class ExampleBot[F[_]: Async : ContextShift](val token: String)
-  extends TelegramBot(token, AsyncHttpClientCatsBackend())
+abstract class ExampleBot[F[_]: ContextShift: Concurrent](val token: String)
+  extends TelegramBot[F](token, AsyncHttpClientCatsBackend.usingClient[F](asyncHttpClient()))

--- a/examples/src-jvm/SttpBackends.scala
+++ b/examples/src-jvm/SttpBackends.scala
@@ -1,5 +1,7 @@
-import com.softwaremill.sttp.okhttp._
+import sttp.client3.okhttp.OkHttpFutureBackend
+import sttp.client3.SttpBackend
+import scala.concurrent.Future
 
 object SttpBackends {
-  val default = OkHttpFutureBackend()
+  val default : SttpBackend[Future, Any] = OkHttpFutureBackend()
 }

--- a/examples/src-monix/EchoBot.scala
+++ b/examples/src-monix/EchoBot.scala
@@ -1,4 +1,3 @@
-import cats.syntax.functor._
 import monix.eval.Task
 
 import com.bot4s.telegram.cats.Polling

--- a/examples/src-monix/ExampleBot.scala
+++ b/examples/src-monix/ExampleBot.scala
@@ -1,5 +1,6 @@
 import com.bot4s.telegram.cats.TelegramBot
-import com.softwaremill.sttp.asynchttpclient.monix.AsyncHttpClientMonixBackend
+import org.asynchttpclient.Dsl.asyncHttpClient
+import sttp.client3.asynchttpclient.monix.AsyncHttpClientMonixBackend
 
 abstract class ExampleBot(val token: String)
-  extends TelegramBot(token, AsyncHttpClientMonixBackend())
+  extends TelegramBot(token, AsyncHttpClientMonixBackend.usingClient(asyncHttpClient()))

--- a/examples/src/CovfefeBot.scala
+++ b/examples/src/CovfefeBot.scala
@@ -1,8 +1,8 @@
 import cats.instances.future._
 import cats.syntax.functor._
-import com.softwaremill.sttp._
 import com.bot4s.telegram.future.Polling
 import com.bot4s.telegram.api.declarative.Commands
+import sttp.client3._
 
 import scala.concurrent.Future
 
@@ -18,13 +18,13 @@ class CovfefeBot(token: String) extends ExampleBot(token)
   onCommand("/start") { implicit msg =>
     reply("Make texting great again!\nUse /covfefe to get a Trump quote.").void
   }
-
+  
   onCommand("/covfefe") { implicit msg =>
     val url = "https://api.whatdoestrumpthink.com/api/v1/quotes/random"
     for {
-      r <- sttp.get(uri"$url").response(asString).send[Future]()
+      r <- quickRequest.get(uri"$url").response(asStringAlways).send(backend)
       if r.isSuccess
-      json = r.unsafeBody
+      json = r.body
       t = io.circe.parser.parse(json).fold(throw _, identity)
       quote = t.hcursor.downField("message").as[String].right.toOption.getOrElse("")
       _ <- reply(quote)


### PR DESCRIPTION
The project was using STTP1. Two majors versions were released and version 3 is now stable.
The migration was done to stay as close as possible from the implementation using STTP1.

A few major changes:

 - Handling error is now done in the `responses` method instead of using `_.unsafeBody`
 - The capabilities type has been changed from `Nothing` to `Any` as described in STTP's documentation
 - Cats' `Async` was changed to `Concurrent`
 - `asyncHttpClient` has to be manually created, we might need to close it as well, but in the scope of bot, this should not be an issue
 
 I've successfully run the following bot after the migration:
  - monix echo bot
  - jvmcats commandsbot
  - jvm randombot
 
 Fixes #104 