### PR TITLE
[cleanup][akka] Remove warning in Akka implementation

### DIFF
--- a/akka/src/com/bot4s/telegram/api/AkkaTelegramBot.scala
+++ b/akka/src/com/bot4s/telegram/api/AkkaTelegramBot.scala
@@ -1,17 +1,14 @@
 package com.bot4s.telegram.api
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.bot4s.telegram.future.TelegramBot
 
 trait AkkaTelegramBot extends TelegramBot with AkkaDefaults
 
 trait AkkaImplicits {
   implicit val system: ActorSystem
-  implicit val materializer: ActorMaterializer
 }
 
 trait AkkaDefaults extends AkkaImplicits {
   implicit val system: ActorSystem = ActorSystem()
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
 }

--- a/akka/src/com/bot4s/telegram/api/GameManager.scala
+++ b/akka/src/com/bot4s/telegram/api/GameManager.scala
@@ -39,7 +39,7 @@ trait GameManager extends WebRoutes {
   import com.bot4s.telegram.marshalling._
 
   private def extractPayload: Directive1[Payload] = {
-    headerValueByName('Referer).map { referer: String =>
+    headerValueByName("Referer").map { referer: String =>
       val parts = referer.split("\\?payload=")
       val encodedPayload = URLDecoder.decode(parts(1), "UTF-8")
       Payload.base64Decode(encodedPayload)

--- a/akka/src/com/bot4s/telegram/api/WebRoutes.scala
+++ b/akka/src/com/bot4s/telegram/api/WebRoutes.scala
@@ -25,7 +25,7 @@ trait WebRoutes extends BotBase[Future] with StrictLogging {
       throw new RuntimeException("Bot is already running")
     }
 
-    bindingFuture = Http().bindAndHandle(routes, interfaceIp, port)
+    bindingFuture = Http().newServerAt(interfaceIp, port).bindFlow(routes)
     bindingFuture.foreach { _ =>
       logger.info(s"Listening on $interfaceIp:$port")
     }

--- a/akka/src/com/bot4s/telegram/clients/YetAnotherAkkaClient.scala
+++ b/akka/src/com/bot4s/telegram/clients/YetAnotherAkkaClient.scala
@@ -26,7 +26,7 @@ class YetAnotherAkkaClient(token: String, telegramHost: String = "api.telegram.o
   import com.bot4s.telegram.marshalling.AkkaHttpMarshalling._
 
   override def sendRequest[R, T <: Request[_]](request: T)(implicit encT: Encoder[T], decR: Decoder[R]): Future[R] = {
-    Source.fromFuture(
+    Source.future(
       Marshal(request).to[RequestEntity]
         .map {
           re =>

--- a/akka/test/src/com/bot4s/telegram/marshalling/AkkaHttpMarshallingSuite.scala
+++ b/akka/test/src/com/bot4s/telegram/marshalling/AkkaHttpMarshallingSuite.scala
@@ -26,7 +26,7 @@ class AkkaHttpMarshallingSuite extends AnyFunSuite with ScalatestRouteTest with 
 
     val entity = SendDocument(channelId, InputFile(fileId), caption = Some(captionWithLineBreak))
     Post("/", Marshal(entity).to[RequestEntity]) ~> {
-      formFields('caption, 'chat_id, 'document) {
+      formFields("caption", "chat_id", "document") {
         (caption, chat_id, document) => complete(caption + chat_id + document)
       }
     } ~> check {
@@ -39,7 +39,7 @@ class AkkaHttpMarshallingSuite extends AnyFunSuite with ScalatestRouteTest with 
     val content = "file content"
     val entity = SendDocument(channelId, AkkaInputFile("Pepe", ByteString(content)))
     Post("/", Marshal(entity).to[RequestEntity]) ~> {
-      formFields('document) {
+      formFields("document") {
         document => complete(document)
       }
     } ~> check {


### PR DESCRIPTION
Remove warnings when compiling the Akka library using 2.13.
All of those are related to the upgrade from 2.X  to 2.6 of Akka.