### PR TITLE
[fix][scala2.13] Convert map view to map in STTP send

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,16 @@ Table of contents
 Add to your `build.sbt` file:
 ```scala
 // Core with minimal dependencies, enough to spawn your first bot.
-libraryDependencies += "com.bot4s" %% "telegram-core" % "5.0.0"
+libraryDependencies += "com.bot4s" %% "telegram-core" % "5.0.1"
 
 // Extra goodies: Webhooks, support for games, bindings for actors.
-libraryDependencies += "com.bot4s" %% "telegram-akka" % "5.0.0"
+libraryDependencies += "com.bot4s" %% "telegram-akka" % "5.0.1"
 ```
 
 For [mill](https://www.lihaoyi.com/mill/) add to your `build.sc` project deps:
 ```scala
-ivy"com.bot4s::telegram-core:5.0.0", // core
-ivy"com.bot4s::telegram-akka:5.0.0"  // extra goodies
+ivy"com.bot4s::telegram-core:5.0.1", // core
+ivy"com.bot4s::telegram-akka:5.0.1"  // extra goodies
 ```
 
 ## Leaking bot tokens

--- a/build.sc
+++ b/build.sc
@@ -111,7 +111,7 @@ abstract class Bot4sTelegramCrossPlatform(val platformSegment: String, location:
 
 trait Publishable extends PublishModule {
 
-  override def publishVersion = "5.0.0"
+  override def publishVersion = "5.0.1"
 
   def pomSettings = PomSettings(
     description = "Telegram Bot API wrapper for Scala",

--- a/core/src/com/bot4s/telegram/clients/SttpClient.scala
+++ b/core/src/com/bot4s/telegram/clients/SttpClient.scala
@@ -63,19 +63,22 @@ class SttpClient[F[_]](token: String, telegramHost: String = "api.telegram.org")
           }
         }
 
-        val fields = parse(marshalling.toJson(request)).fold(
-          throw _,
-          _.asObject.map {
-            _.toMap.mapValues { json =>
-              json.asString.getOrElse(json.printWith(marshalling.printer))
+        val fields = parse(marshalling.toJson(request))
+          .fold(
+            throw _,
+            _.asObject.map {
+              _.toMap.mapValues { json =>
+                json.asString.getOrElse(json.printWith(marshalling.printer))
+              }.toMap
             }
-          }
-        )
+          )
 
-        val params = fields.getOrElse(Map())
+        val params = fields.getOrElse(Map()).toMap
 
         quickRequest.post(uri"$url?$params").multipartBody(parts)
     }
+
+    logger.debug(sttpRequest.toCurl)
 
     import com.bot4s.telegram.marshalling.responseDecoder
 


### PR DESCRIPTION
The map of parameters was not correctly parsed in all cases and the string `MapView(<not computed>)` was sent to the server.
This only happened in Scala 2.13. 

This PR explicitly converts the MapView to a Map