### PR TITLE
Wrap Update to include errors

### DIFF
--- a/core/src/com/bot4s/telegram/api/Polling.scala
+++ b/core/src/com/bot4s/telegram/api/Polling.scala
@@ -1,10 +1,10 @@
 package com.bot4s.telegram.api
 
 import com.bot4s.telegram.methods.GetUpdates
-import com.bot4s.telegram.models.Update
 import com.typesafe.scalalogging.StrictLogging
 
 import scala.concurrent.duration.{ Duration, _ }
+import com.bot4s.telegram.models.ParsedUpdate
 
 /**
  * Provides updates by (long) polling Telegram servers.
@@ -28,7 +28,7 @@ private[telegram] trait Polling[F[_]] extends BotBase[F] with StrictLogging {
    *
    * @param offset
    */
-  def pollingGetUpdates(offset: Option[Long]): F[Seq[Update]] =
+  def pollingGetUpdates(offset: Option[Long]): F[Seq[ParsedUpdate]] =
     request(
       GetUpdates(
         offset,

--- a/core/src/com/bot4s/telegram/cats/Polling.scala
+++ b/core/src/com/bot4s/telegram/cats/Polling.scala
@@ -9,9 +9,9 @@ import com.bot4s.telegram.api.{ Polling => BasePolling }
 import com.bot4s.telegram.methods.{ DeleteWebhook, GetMe }
 import com.bot4s.telegram.models.User
 import com.typesafe.scalalogging.StrictLogging
+import com.bot4s.telegram.models.ParsedUpdate
 
 case class PollingState(botUser: User, offset: Option[Long])
-
 trait Polling[F[_]] extends BasePolling[F] with StrictLogging {
 
   implicit val monad: MonadError[F, Throwable]
@@ -19,14 +19,20 @@ trait Polling[F[_]] extends BasePolling[F] with StrictLogging {
   private def poll(state: PollingState): F[Unit] =
     for {
       updates <- pollingGetUpdates(state.offset.map(_ + 1))
-      _ <- updates.toList.traverse { update =>
+      _ <- updates.toList.collect { case u @ ParsedUpdate.Failure(_, _) => u }.traverse { update =>
+             monad.pure(logger.error(s"Unable to decode message ${update.updateId}: ${update.cause}"))
+           }
+      _ <- updates.toList.collect { case ParsedUpdate.Success(u) => u }.traverse { update =>
              monad.handleErrorWith(receiveUpdate(update, Some(state.botUser))) { e =>
                logger.warn(s"Can not process updates $update", e)
                unit
              }
            }
       nextOffset = updates
-                     .foldLeft(state.offset) { case (acc, u) => Some(acc.fold(u.updateId)(u.updateId max _)) }
+                     .foldLeft(state.offset) {
+                       case (acc, ParsedUpdate.Success(u))     => Some(acc.fold(u.updateId)(u.updateId max _))
+                       case (acc, ParsedUpdate.Failure(id, _)) => Some(acc.fold(id)(id max _))
+                     }
       _ <- poll(state.copy(offset = nextOffset))
     } yield ()
 

--- a/core/src/com/bot4s/telegram/cats/Polling.scala
+++ b/core/src/com/bot4s/telegram/cats/Polling.scala
@@ -21,7 +21,7 @@ trait Polling[F[_]] extends BasePolling[F] with StrictLogging {
       updates <- pollingGetUpdates(state.offset.map(_ + 1))
       _ <- updates.toList.map {
              case ParsedUpdate.Failure(updateId, cause) =>
-               logger.error(s"Unable to decode update ${updateId}: ${cause.message}")
+               logger.error(s"Unable to decode update ${updateId}: ${cause.getMessage()}")
                unit
              case ParsedUpdate.Success(update) =>
                monad.handleErrorWith(receiveUpdate(update, Some(state.botUser))) { e =>

--- a/core/src/com/bot4s/telegram/future/Polling.scala
+++ b/core/src/com/bot4s/telegram/future/Polling.scala
@@ -43,7 +43,10 @@ trait Polling extends BasePolling[Future] with BotExecutionContext with StrictLo
           u match {
             case ParsedUpdate.Success(u) =>
               receiveUpdate(u, Some(user))
-            case _ => Future.unit
+            case ParsedUpdate.Failure(id, cause) =>
+              Future(
+                logger.error(s"Unable to decode update $id: ${cause.message}")
+              )
           }
         } catch {
           case NonFatal(e) =>

--- a/core/src/com/bot4s/telegram/future/Polling.scala
+++ b/core/src/com/bot4s/telegram/future/Polling.scala
@@ -2,12 +2,11 @@ package com.bot4s.telegram.future
 
 import com.bot4s.telegram.api.{ Polling => BasePolling }
 import com.bot4s.telegram.methods.{ DeleteWebhook, GetMe }
-import com.bot4s.telegram.models.User
+import com.bot4s.telegram.models.{ ParsedUpdate, User }
 import com.typesafe.scalalogging.StrictLogging
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal
-import com.bot4s.telegram.models.ParsedUpdate
 
 trait Polling extends BasePolling[Future] with BotExecutionContext with StrictLogging {
 

--- a/core/src/com/bot4s/telegram/future/Polling.scala
+++ b/core/src/com/bot4s/telegram/future/Polling.scala
@@ -42,7 +42,7 @@ trait Polling extends BasePolling[Future] with BotExecutionContext with StrictLo
               receiveUpdate(u, Some(user))
             case ParsedUpdate.Failure(id, cause) =>
               Future(
-                logger.error(s"Unable to decode update $id: ${cause.message}")
+                logger.error(s"Unable to decode update $id: ${cause.getMessage()}")
               )
           }
         } catch {

--- a/core/src/com/bot4s/telegram/future/Polling.scala
+++ b/core/src/com/bot4s/telegram/future/Polling.scala
@@ -17,15 +17,13 @@ trait Polling extends BasePolling[Future] with BotExecutionContext with StrictLo
 
   private def poll(seed: Future[OffsetUpdates]): Future[OffsetUpdates] =
     seed.flatMap { case (offset, updates, user) =>
-      val maxReceivedOffset = updates.map {
+      val maxOffset = updates.map {
         case ParsedUpdate.Failure(id, _)  => id
         case ParsedUpdate.Success(update) => update.updateId
-      }.max
-
-      val maxOffset = Some(
-        offset
-          .fold(maxReceivedOffset)(_ max maxReceivedOffset)
-      )
+      }
+        .foldLeft(offset) { (acc, e) =>
+          Some(acc.fold(e)(e max _))
+        }
 
       // Spawn next request before processing updates.
       val f =

--- a/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
@@ -19,6 +19,7 @@ import com.bot4s.telegram.models._
 import io.circe.Decoder
 import io.circe.generic.semiauto._
 import com.typesafe.scalalogging.StrictLogging
+import io.circe.HCursor
 
 /**
  * Circe marshalling borrowed/inspired from [[https://github.com/nikdon/telepooz]]
@@ -148,6 +149,21 @@ trait CirceDecoders extends StrictLogging {
   implicit val responseParametersDecoder: Decoder[ResponseParameters] = deriveDecoder[ResponseParameters]
 
   implicit val updateDecoder: Decoder[Update] = deriveDecoder[Update]
+
+  implicit val parseUpdateDecoder: Decoder[ParsedUpdate] = new Decoder[ParsedUpdate] {
+    final def apply(c: HCursor): Decoder.Result[ParsedUpdate] = {
+      val root   = c
+      val update = updateDecoder(c)
+
+      update match {
+        case Left(e) =>
+          for {
+            id <- root.get[Long]("updateId")
+          } yield ParsedUpdate.Failure(id, e)
+        case Right(value) => Right(ParsedUpdate.Success(value))
+      }
+    }
+  }
 
   implicit val loginUrlDecoder: Decoder[LoginUrl] = deriveDecoder[LoginUrl]
 

--- a/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
@@ -81,7 +81,7 @@ trait CirceDecoders extends StrictLogging {
   implicit val contactDecoder: Decoder[Contact]                           = deriveDecoder[Contact]
   implicit val documentDecoder: Decoder[Document]                         = deriveDecoder[Document]
   implicit val fileDecoder: Decoder[File]                                 = deriveDecoder[File]
-  implicit val callbackGameDecoder: Decoder[CallbackGame]                 = deriveDecoder[CallbackGame]
+  implicit val callbackGameDecoder: Decoder[CallbackGame]                 = Decoder.const(CallbackGame)
   implicit val inlineKeyboardButtonDecoder: Decoder[InlineKeyboardButton] = deriveDecoder[InlineKeyboardButton]
 
   implicit val inlineKeyboardMarkupDecoder: Decoder[InlineKeyboardMarkup] = deriveDecoder[InlineKeyboardMarkup]

--- a/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
@@ -150,15 +150,14 @@ trait CirceDecoders extends StrictLogging {
 
   implicit val updateDecoder: Decoder[Update] = deriveDecoder[Update]
 
-  implicit val parseUpdateDecoder: Decoder[ParsedUpdate] = new Decoder[ParsedUpdate] {
+  implicit val parsedUpdateDecoder: Decoder[ParsedUpdate] = new Decoder[ParsedUpdate] {
     final def apply(c: HCursor): Decoder.Result[ParsedUpdate] = {
-      val root   = c
       val update = updateDecoder(c)
 
       update match {
         case Left(e) =>
           for {
-            id <- root.get[Long]("updateId")
+            id <- c.get[Long]("updateId")
           } yield ParsedUpdate.Failure(id, e)
         case Right(value) => Right(ParsedUpdate.Success(value))
       }

--- a/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
@@ -19,6 +19,7 @@ import io.circe.generic.extras._
 import io.circe.generic.extras.auto._
 import io.circe.generic.extras.semiauto._
 import io.circe.syntax._
+import io.circe.JsonObject
 
 /**
  * Circe marshalling borrowed/inspired from [[https://github.com/nikdon/telepooz]]
@@ -31,7 +32,8 @@ trait CirceEncoders {
   implicit val audioEncoder: Encoder[Audio]                 = deriveConfiguredEncoder[Audio]
   implicit val callbackQueryEncoder: Encoder[CallbackQuery] = deriveConfiguredEncoder[CallbackQuery]
 
-  implicit val callbackGameEncoder: Encoder[CallbackGame] = deriveConfiguredEncoder[CallbackGame]
+  implicit val callbackGameEncoder: Encoder[CallbackGame] =
+    Encoder.encodeJsonObject.contramap[CallbackGame](_ => JsonObject.empty)
 
   implicit val chatTypeEncoder: Encoder[ChatType] =
     Encoder[String].contramap[ChatType](e => CaseConversions.snakenize(e.toString))

--- a/core/src/com/bot4s/telegram/methods/GetUpdates.scala
+++ b/core/src/com/bot4s/telegram/methods/GetUpdates.scala
@@ -1,7 +1,7 @@
 package com.bot4s.telegram.methods
 
-import com.bot4s.telegram.models.Update
 import com.bot4s.telegram.models.UpdateType.UpdateType
+import com.bot4s.telegram.models.ParsedUpdate
 
 /**
  * Use this method to receive incoming updates using long polling (wiki). An Array of Update objects is returned.
@@ -25,4 +25,4 @@ case class GetUpdates(
   limit: Option[Int] = None,
   timeout: Option[Int] = None,
   allowedUpdates: Option[Seq[UpdateType]] = None
-) extends JsonRequest[Seq[Update]]
+) extends JsonRequest[Seq[ParsedUpdate]]

--- a/core/src/com/bot4s/telegram/models/Update.scala
+++ b/core/src/com/bot4s/telegram/models/Update.scala
@@ -1,5 +1,7 @@
 package com.bot4s.telegram.models
 
+import io.circe.DecodingFailure
+
 /**
  * This object represents an incoming update.
  * At most one of the optional parameters can be present in any given update.
@@ -56,4 +58,10 @@ case class Update(
     ).count(_.isDefined) == 1,
     "Exactly one of the optional fields should be used"
   )
+}
+
+sealed trait ParsedUpdate
+object ParsedUpdate {
+  case class Failure(updateId: Long, cause: DecodingFailure) extends ParsedUpdate
+  case class Success(update: Update)                         extends ParsedUpdate
 }

--- a/core/src/com/bot4s/telegram/models/Update.scala
+++ b/core/src/com/bot4s/telegram/models/Update.scala
@@ -60,6 +60,10 @@ case class Update(
   )
 }
 
+/*
+The following ADT represents either an update from Telegram's API or a parsing error that might
+happens when an unsupported message or an update from a newer/changed API is parsed by the client.
+ */
 sealed trait ParsedUpdate
 object ParsedUpdate {
   case class Failure(updateId: Long, cause: DecodingFailure) extends ParsedUpdate

--- a/core/test/src/com/bot4s/telegram/marshalling/MarshallingSuite.scala
+++ b/core/test/src/com/bot4s/telegram/marshalling/MarshallingSuite.scala
@@ -117,4 +117,9 @@ class MarshallingSuite extends AnyFlatSpec with MockFactory with Matchers with T
 
     update.updateId shouldBe 42
   }
+
+  it should "decode and encode a CallbackGame" in {
+    toJson[CallbackGame](CallbackGame) shouldBe """{}"""
+    fromJson[CallbackGame]("""{}""") shouldBe CallbackGame
+  }
 }

--- a/core/test/src/com/bot4s/telegram/marshalling/MarshallingSuite.scala
+++ b/core/test/src/com/bot4s/telegram/marshalling/MarshallingSuite.scala
@@ -79,9 +79,9 @@ class MarshallingSuite extends AnyFlatSpec with MockFactory with Matchers with T
                      |}""".stripMargin) shouldBe User(id = 123, isBot = true, firstName = "Pepe")
   }
 
-  it should "Correctly decode an update" in {
+  it should "correctly extract an update_id from an unsupported/invalid update" in {
     // The following message is invalid, it is missing the 'editedMessage' field in the game part
-    val x = fromJson[ParsedUpdate](
+    val update = fromJson[ParsedUpdate](
       """{
         |"update_id": 42,
         |"edited_message": {
@@ -115,6 +115,6 @@ class MarshallingSuite extends AnyFlatSpec with MockFactory with Matchers with T
         |}""".stripMargin
     ).asInstanceOf[ParsedUpdate.Failure]
 
-    x.updateId shouldBe 42
+    update.updateId shouldBe 42
   }
 }


### PR DESCRIPTION
The `ParsedUpdate` type was introduce in order to be able to represent parsing issues in the `GetUpdates` endpoint.
With the previous implementation, when a new or unknown type of message was received by the client, the parser would fail and cause the bot to stop parsing new messages.
The new implementation extracts the `update_id` message in case of parsing issue in order to acknowledge the message and receive the next ones. It also extracts and logs the decoding error from Circe in order to fix them in the next release of the library.

This PR also includes a fix to run some tests that were skipped so far as well as correctly serializing the `CallbackGame` case object.

See #143 