### PR TITLE
Add Api 5.4 changes

### DIFF
--- a/core/src/com/bot4s/telegram/api/BotBase.scala
+++ b/core/src/com/bot4s/telegram/api/BotBase.scala
@@ -48,7 +48,8 @@ trait BotBase[F[_]] {
       u.chosenInlineResult.map(receiveChosenInlineResult _),
       u.callbackQuery.map(receiveCallbackQuery _),
       u.shippingQuery.map(receiveShippingQuery _),
-      u.preCheckoutQuery.map(receivePreCheckoutQuery _)
+      u.preCheckoutQuery.map(receivePreCheckoutQuery _),
+      u.chatJoinRequest.map(receiveJoinRequest _)
     ).flatten.sequence_
 
   protected lazy val unit = monad.pure(())
@@ -67,6 +68,7 @@ trait BotBase[F[_]] {
 
   def receiveShippingQuery(shippingQuery: ShippingQuery): F[Unit]          = unit
   def receivePreCheckoutQuery(preCheckoutQuery: PreCheckoutQuery): F[Unit] = unit
+  def receiveJoinRequest(joinRequest: ChatJoinRequest): F[Unit]            = unit
 
   def run(): F[Unit] = unit
   def shutdown(): Unit = {}

--- a/core/src/com/bot4s/telegram/api/RequestHandler.scala
+++ b/core/src/com/bot4s/telegram/api/RequestHandler.scala
@@ -44,10 +44,13 @@ abstract class RequestHandler[F[_]](implicit monadError: MonadError[F, Throwable
   private def sendRequestInternal[R](request: Request[R]): F[R] =
     request match {
       // Pure JSON requests
+      case s: ApproveChatJoinRequest          => sendRequest[R, ApproveChatJoinRequest](s)
       case s: AnswerCallbackQuery             => sendRequest[R, AnswerCallbackQuery](s)
       case s: AnswerInlineQuery               => sendRequest[R, AnswerInlineQuery](s)
       case s: AnswerPreCheckoutQuery          => sendRequest[R, AnswerPreCheckoutQuery](s)
       case s: AnswerShippingQuery             => sendRequest[R, AnswerShippingQuery](s)
+      case s: CreateChatInviteLink            => sendRequest[R, CreateChatInviteLink](s)
+      case s: DeclineChatJoinRequest          => sendRequest[R, DeclineChatJoinRequest](s)
       case s: DeleteChatPhoto                 => sendRequest[R, DeleteChatPhoto](s)
       case s: DeleteChatStickerSet            => sendRequest[R, DeleteChatStickerSet](s)
       case s: DeleteMessage                   => sendRequest[R, DeleteMessage](s)

--- a/core/src/com/bot4s/telegram/api/declarative/JoinRequests.scala
+++ b/core/src/com/bot4s/telegram/api/declarative/JoinRequests.scala
@@ -1,0 +1,31 @@
+package com.bot4s.telegram.api.declarative
+
+import cats.instances.list._
+import cats.syntax.functor._
+import cats.syntax.flatMap._
+import cats.syntax.traverse._
+import com.bot4s.telegram.api.BotBase
+
+import scala.collection.mutable
+import com.bot4s.telegram.models.ChatJoinRequest
+
+/**
+ * Declarative interface for processing join requests.
+ */
+trait JoinRequests[F[_]] extends BotBase[F] {
+
+  private val joinRequests = mutable.ArrayBuffer[Action[F, ChatJoinRequest]]()
+
+  /**
+   * Executes 'action' for every join request
+   */
+  def onJoinRequest(action: Action[F, ChatJoinRequest]): Unit =
+    joinRequests += action
+
+  override def receiveJoinRequest(joinRequest: ChatJoinRequest): F[Unit] =
+    for {
+      _ <- joinRequests.toList.traverse(action => action(joinRequest))
+      _ <- super.receiveJoinRequest(joinRequest)
+    } yield ()
+
+}

--- a/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
@@ -73,6 +73,8 @@ trait CirceDecoders extends StrictLogging {
   implicit val chatInviteLinkDecoder: Decoder[ChatInviteLink]       = deriveDecoder[ChatInviteLink]
   implicit val chatMemberUpdatedDecoder: Decoder[ChatMemberUpdated] = deriveDecoder[ChatMemberUpdated]
 
+  implicit val chatJoinrequestDecoder: Decoder[ChatJoinRequest] = deriveDecoder[ChatJoinRequest]
+
   implicit val audioDecoder: Decoder[Audio] = deriveDecoder[Audio]
 
   implicit val chatDecoder: Decoder[Chat]           = deriveDecoder[Chat]

--- a/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
@@ -230,6 +230,14 @@ trait CirceEncoders {
   implicit val chatInviteLinkEncoder: Encoder[ChatInviteLink]       = deriveConfiguredEncoder[ChatInviteLink]
   implicit val chatMemberUpdatedEncoder: Encoder[ChatMemberUpdated] = deriveConfiguredEncoder[ChatMemberUpdated]
 
+  implicit val createChatInviteLinkEncoder: Encoder[CreateChatInviteLink] =
+    deriveConfiguredEncoder[CreateChatInviteLink]
+  implicit val editChatInviteLinkEncoder: Encoder[EditChatInviteLink] = deriveConfiguredEncoder[EditChatInviteLink]
+  implicit val approveChatJoinrequestEncoder: Encoder[ApproveChatJoinRequest] =
+    deriveConfiguredEncoder[ApproveChatJoinRequest]
+  implicit val declineChatJoinrequestEncoder: Encoder[DeclineChatJoinRequest] =
+    deriveConfiguredEncoder[DeclineChatJoinRequest]
+
   // Ignore InputFiles as JSON.
   implicit def inputFileEncoder: Encoder[InputFile] = Encoder.instance(_ => io.circe.Json.Null)
 

--- a/core/src/com/bot4s/telegram/methods/ApproveChatJoinRequest.scala
+++ b/core/src/com/bot4s/telegram/methods/ApproveChatJoinRequest.scala
@@ -1,0 +1,16 @@
+package com.bot4s.telegram.methods
+
+import com.bot4s.telegram.models.ChatId
+
+/**
+ * Use this method to approve a chat join request.
+ * The bot must be an administrator in the chat for this to work and must have the can_invite_users administrator right.
+ * Returns True on success.
+ *
+ * @param chatId 	Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+ * @param userId 	Long Unique identifier of the target user
+ */
+case class ApproveChatJoinRequest(
+  chatId: ChatId,
+  userId: Long
+) extends JsonRequest[Boolean]

--- a/core/src/com/bot4s/telegram/methods/ChatAction.scala
+++ b/core/src/com/bot4s/telegram/methods/ChatAction.scala
@@ -9,11 +9,12 @@ package com.bot4s.telegram.methods
  *   record_video or upload_video for videos,
  *   record_audio or upload_audio for audio files,
  *   upload_document for general files,
+ *   choose_sticker for sticker
  *   find_location for location data,
  *   record_video_note or upload_video_note for video notes.
  */
 object ChatAction extends Enumeration {
   type ChatAction = Value
-  val Typing, UploadPhoto, RecordVideo, UploadVideo, RecordAudio, UploadAudio, UploadDocument, FindLocation,
-    RecordVideoNote, UploadVideoNote = Value
+  val Typing, UploadPhoto, RecordVideo, UploadVideo, RecordAudio, UploadAudio, UploadDocument, ChooseSticker,
+    FindLocation, RecordVideoNote, UploadVideoNote = Value
 }

--- a/core/src/com/bot4s/telegram/methods/CreateChatInviteLink.scala
+++ b/core/src/com/bot4s/telegram/methods/CreateChatInviteLink.scala
@@ -1,0 +1,27 @@
+package com.bot4s.telegram.methods
+
+import com.bot4s.telegram.models.ChatId
+import com.bot4s.telegram.models.ChatInviteLink
+
+/**
+ * Use this method to create an additional invite link for a chat.
+ * The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights.
+ * The link can be revoked using the method revokeChatInviteLink. Returns the new invite link as ChatInviteLink object.
+ *
+ * @param chatId 	            Integer or String Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+ * @param name 	              String Invite link name; 0-32 characters
+ * @param expireDate 	        Integer	Point in time (Unix timestamp) when the link will expire
+ * @param memberLimit 	      Integer Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999
+ * @param createsJoinRequest 	Boolean True, if users joining the chat via the link need to be approved by chat administrators. If True, member_limit can't be specified
+ */
+case class CreateChatInviteLink(
+  chatId: ChatId,
+  name: Option[String] = None,
+  expireDate: Option[Int] = None,
+  memberLimit: Option[Int] = None,
+  createsJoinRequest: Option[Boolean] = None
+) extends JsonRequest[ChatInviteLink] {
+
+  if (createsJoinRequest.fold(false)(identity))
+    require(memberLimit.isEmpty, "memberLimit can't be specified if createsJoinRequest is set")
+}

--- a/core/src/com/bot4s/telegram/methods/CreateChatInviteLink.scala
+++ b/core/src/com/bot4s/telegram/methods/CreateChatInviteLink.scala
@@ -8,11 +8,11 @@ import com.bot4s.telegram.models.ChatInviteLink
  * The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights.
  * The link can be revoked using the method revokeChatInviteLink. Returns the new invite link as ChatInviteLink object.
  *
- * @param chatId 	            Integer or String Unique identifier for the target chat or username of the target channel (in the format @channelusername)
- * @param name 	              String Invite link name; 0-32 characters
- * @param expireDate 	        Integer	Point in time (Unix timestamp) when the link will expire
- * @param memberLimit 	      Integer Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999
- * @param createsJoinRequest 	Boolean True, if users joining the chat via the link need to be approved by chat administrators. If True, member_limit can't be specified
+ * @param chatId                Integer or String Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+ * @param name                  String Invite link name; 0-32 characters
+ * @param expireDate            Integer  Point in time (Unix timestamp) when the link will expire
+ * @param memberLimit           Integer Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999
+ * @param createsJoinRequest    Boolean True, if users joining the chat via the link need to be approved by chat administrators. If True, member_limit can't be specified
  */
 case class CreateChatInviteLink(
   chatId: ChatId,

--- a/core/src/com/bot4s/telegram/methods/DeclineChatJoinRequest.scala
+++ b/core/src/com/bot4s/telegram/methods/DeclineChatJoinRequest.scala
@@ -1,0 +1,16 @@
+package com.bot4s.telegram.methods
+
+import com.bot4s.telegram.models.ChatId
+
+/**
+ * Use this method to decline a chat join request.
+ * The bot must be an administrator in the chat for this to work and must have the can_invite_users administrator right.
+ * Returns True on success.
+ *
+ * @param chatId 	Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+ * @param userId 	Long Unique identifier of the target user
+ */
+case class DeclineChatJoinRequest(
+  chatId: ChatId,
+  userId: Long
+) extends JsonRequest[Boolean]

--- a/core/src/com/bot4s/telegram/methods/EditChatInviteLink.scala
+++ b/core/src/com/bot4s/telegram/methods/EditChatInviteLink.scala
@@ -1,0 +1,29 @@
+package com.bot4s.telegram.methods
+
+import com.bot4s.telegram.models.ChatId
+import com.bot4s.telegram.models.ChatInviteLink
+
+/**
+ * Use this method to edit a non-primary invite link created by the bot.
+ * The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights.
+ * Returns the edited invite link as a ChatInviteLink object.
+ *
+ * @param chatId 	            Integer or String Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+ * @param inviteLink 	          String The invite link to edit
+ * @param name 	                String Invite link name; 0-32 characters
+ * @param expireDate 	        Integer Point in time (Unix timestamp) when the link will expire
+ * @param memberLimit 	        Integer Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999
+ * @param createsJoinRequest 	Boolean True, if users joining the chat via the link need to be approved by chat administrators. If True, member_limit can't be specified
+ */
+case class EditChatInviteLink(
+  chatId: ChatId,
+  inviteLink: String,
+  name: Option[String] = None,
+  expireDate: Option[Int] = None,
+  memberLimit: Option[Int] = None,
+  createsJoinRequest: Option[Boolean] = None
+) extends JsonRequest[ChatInviteLink] {
+
+  if (createsJoinRequest.fold(false)(identity))
+    require(memberLimit.isEmpty, "memberLimit can't be specified if createsJoinRequest is set")
+}

--- a/core/src/com/bot4s/telegram/methods/EditChatInviteLink.scala
+++ b/core/src/com/bot4s/telegram/methods/EditChatInviteLink.scala
@@ -9,10 +9,10 @@ import com.bot4s.telegram.models.ChatInviteLink
  * Returns the edited invite link as a ChatInviteLink object.
  *
  * @param chatId 	            Integer or String Unique identifier for the target chat or username of the target channel (in the format @channelusername)
- * @param inviteLink 	          String The invite link to edit
- * @param name 	                String Invite link name; 0-32 characters
+ * @param inviteLink 	        String The invite link to edit
+ * @param name 	              String Invite link name; 0-32 characters
  * @param expireDate 	        Integer Point in time (Unix timestamp) when the link will expire
- * @param memberLimit 	        Integer Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999
+ * @param memberLimit 	      Integer Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999
  * @param createsJoinRequest 	Boolean True, if users joining the chat via the link need to be approved by chat administrators. If True, member_limit can't be specified
  */
 case class EditChatInviteLink(

--- a/core/src/com/bot4s/telegram/models/Chat.scala
+++ b/core/src/com/bot4s/telegram/models/Chat.scala
@@ -38,4 +38,6 @@ case class Chat(
   permissions: Option[ChatPermissions] = None,
   stickerSetName: Option[String] = None,
   canSetStickerSet: Option[Boolean] = None
-)
+) {
+  val chatId = ChatId(id)
+}

--- a/core/src/com/bot4s/telegram/models/ChatInviteLink.scala
+++ b/core/src/com/bot4s/telegram/models/ChatInviteLink.scala
@@ -3,20 +3,26 @@ package com.bot4s.telegram.models
 /**
  * This object represents an invite link for a chat.
  *
- * @param creator                Creator of the link
- * @param expireDate             Optional. Point in time (Unix timestamp) when the link will expire or has been expired
- * @param inviteLink             The invite link. If the link was created by another chat administrator, then the second
- *                               part of the link will be replaced with “…”.
- * @param isPrimary              True, if the link is primary
- * @param isRevoked              True, if the link is revoked
- * @param memberLimit            Optional. Maximum number of users that can be members of the chat simultaneously after joining the chat
- *                               via this invite link; 1-99999
+ * @param creator                   Creator of the link
+ * @param createsJoinRequest        True, if users joining the chat via the link need to be approved by chat administrators
+ * @param expireDate                Optional. Point in time (Unix timestamp) when the link will expire or has been expired
+ * @param inviteLink                The invite link. If the link was created by another chat administrator, then the second
+ *                                  part of the link will be replaced with “…”.
+ * @param isPrimary                 True, if the link is primary
+ * @param isRevoked                 True, if the link is revoked
+ * @param name                      Invite link name
+ * @param memberLimit               Maximum number of users that can be members of the chat simultaneously after joining the chat
+ *                                  via this invite link; 1-99999
+ * @param pendingJoinRequestCount   Number of pending join requests created using this link
  */
 case class ChatInviteLink(
   creator: User,
+  createsJoinRequest: Boolean,
   expireDate: Option[Int] = None,
   inviteLink: String,
   isPrimary: Boolean,
   isRevoked: Boolean,
-  memberLimit: Option[Int] = None
-) {}
+  name: Option[String] = None,
+  memberLimit: Option[Int] = None,
+  pendingJoinRequestCount: Option[Int] = None
+)

--- a/core/src/com/bot4s/telegram/models/ChatJoinRequest.scala
+++ b/core/src/com/bot4s/telegram/models/ChatJoinRequest.scala
@@ -1,0 +1,21 @@
+package com.bot4s.telegram.models
+
+/**
+ * This object represents an invite link for a chat.
+ *
+ * @param creator                Creator of the link
+ * @param expireDate             Optional. Point in time (Unix timestamp) when the link will expire or has been expired
+ * @param inviteLink             The invite link. If the link was created by another chat administrator, then the second
+ *                               part of the link will be replaced with “…”.
+ * @param isPrimary              True, if the link is primary
+ * @param isRevoked              True, if the link is revoked
+ * @param memberLimit            Optional. Maximum number of users that can be members of the chat simultaneously after joining the chat
+ *                               via this invite link; 1-99999
+ */
+case class ChatJoinRequest(
+  chat: Chat,
+  from: User,
+  date: Int,
+  bio: Option[String] = None,
+  inviteLink: Option[ChatInviteLink] = None
+)

--- a/core/src/com/bot4s/telegram/models/ChatJoinRequest.scala
+++ b/core/src/com/bot4s/telegram/models/ChatJoinRequest.scala
@@ -1,16 +1,14 @@
 package com.bot4s.telegram.models
 
 /**
- * This object represents an invite link for a chat.
+ * Represents a join request sent to a chat.
  *
- * @param creator                Creator of the link
- * @param expireDate             Optional. Point in time (Unix timestamp) when the link will expire or has been expired
- * @param inviteLink             The invite link. If the link was created by another chat administrator, then the second
- *                               part of the link will be replaced with “…”.
- * @param isPrimary              True, if the link is primary
- * @param isRevoked              True, if the link is revoked
- * @param memberLimit            Optional. Maximum number of users that can be members of the chat simultaneously after joining the chat
- *                               via this invite link; 1-99999
+ * @param chat          Chat to which the request was sent
+ * @param from          User that sent the join request
+ * @param date          Integer Date the request was sent in Unix time
+ * @param bio           String Optional. Bio of the user.
+ * @param inviteLink    ChatInviteLink Optional. Chat invite link that was used by the user to send the join request
+ *                      via this invite link; 1-99999
  */
 case class ChatJoinRequest(
   chat: Chat,

--- a/core/src/com/bot4s/telegram/models/Update.scala
+++ b/core/src/com/bot4s/telegram/models/Update.scala
@@ -38,7 +38,8 @@ case class Update(
   preCheckoutQuery: Option[PreCheckoutQuery] = None,
   poll: Option[Poll] = None,
   myChatMember: Option[ChatMemberUpdated] = None,
-  chatMember: Option[ChatMemberUpdated] = None
+  chatMember: Option[ChatMemberUpdated] = None,
+  chatJoinRequest: Option[ChatJoinRequest] = None
 ) {
 
   require(
@@ -54,7 +55,8 @@ case class Update(
       preCheckoutQuery,
       poll,
       myChatMember,
-      chatMember
+      chatMember,
+      chatJoinRequest
     ).count(_.isDefined) == 1,
     "Exactly one of the optional fields should be used"
   )

--- a/examples/src/JoinRequestBot.scala
+++ b/examples/src/JoinRequestBot.scala
@@ -11,9 +11,7 @@ import com.bot4s.telegram.methods.ApproveChatJoinRequest
 import com.bot4s.telegram.methods.DeclineChatJoinRequest
 
 /**
- * Showcases different ways to declare commands (Commands + RegexCommands).
- *
- * Note that non-ASCII commands are not clickable.
+ * Showcases registration and join request (bot must be admin)
  *
  * @param token Bot's token.
  */

--- a/examples/src/JoinRequestBot.scala
+++ b/examples/src/JoinRequestBot.scala
@@ -1,0 +1,46 @@
+import cats.instances.future._
+import cats.syntax.functor._
+import com.bot4s.telegram.api.declarative.{ Commands, JoinRequests }
+
+import scala.concurrent.Future
+import com.bot4s.telegram.methods.CreateChatInviteLink
+import com.bot4s.telegram.methods.CreateChatInviteLink
+import com.bot4s.telegram.api.declarative._
+import com.bot4s.telegram.models._
+import com.bot4s.telegram.methods.ApproveChatJoinRequest
+import com.bot4s.telegram.methods.DeclineChatJoinRequest
+
+/**
+ * Showcases different ways to declare commands (Commands + RegexCommands).
+ *
+ * Note that non-ASCII commands are not clickable.
+ *
+ * @param token Bot's token.
+ */
+class JoinRequestBot(token: String) extends ExampleBot(token) with JoinRequests[Future] with Commands[Future] {
+
+  var accept: Boolean = true
+
+  onJoinRequest { joinRequest =>
+    if (accept)
+      request(ApproveChatJoinRequest(joinRequest.chat.chatId, joinRequest.from.id)).void
+    else
+      request(DeclineChatJoinRequest(joinRequest.chat.chatId, joinRequest.from.id)).void
+  }
+
+  // String commands.
+  onCommand("/accept") { _ =>
+    Future { accept = true }
+  }
+
+  onCommand("/deny") { _ =>
+    Future { accept = false }
+  }
+
+  onCommand("/link") { implicit msg =>
+    request(CreateChatInviteLink(ChatId(msg.chat.id), createsJoinRequest = Some(true))).flatMap { link =>
+      reply(s"Invite link is ${link.inviteLink}").void
+    }.recoverWith { case error => reply(s"Unable to create link ${error}").void }
+  }
+
+}


### PR DESCRIPTION
## November 5, 2021

Bot API 5.4

-  Added the the parameter creates_join_request to the methods createChatInviteLink and editChatInviteLink for managing chat invite links that create join requests (read more about this on our blog).
-  Added the fields creates_join_request and pending_join_request_count to the class ChatInviteLink.
-  Added the field name to the class ChatInviteLink and the parameters name to the methods createChatInviteLink and editChatInviteLink for managing invite link names.
-   Added updates about new requests to join the chat, represented by the class ChatJoinRequest and the field chat_join_request in the Update class. The bot must be an administrator in the chat with the can_invite_users administrator right to receive these updates.
-   Added the methods approveChatJoinRequest and declineChatJoinRequest for managing requests to join the chat.
-   Added support for the choose_sticker action in the method sendChatAction.
