### PR TITLE
[api] Re-enable support for unicode commands

### DIFF
--- a/core/src/com/bot4s/telegram/api/declarative/Commands.scala
+++ b/core/src/com/bot4s/telegram/api/declarative/Commands.scala
@@ -55,7 +55,7 @@ trait Commands[F[_]] extends Messages[F] with CommandImplicits {
    */
   def command(msg: Message): Option[Command] =
     msg.text.flatMap { text =>
-      val cmdRe = """^(?:\s*/)(\w+)(?:@(\w+))?""".r // /cmd@recipient
+      val cmdRe = """^(?:\s*/)([\p{L}|\p{S}]+)(?:@([\p{L}|\p{S}]+))?""".r // /cmd@recipient
       cmdRe.findFirstIn(text) flatMap {
         case cmdRe(cmd, recipient) => Some(Command(cmd, Option(recipient)))
         case _                     => None
@@ -102,7 +102,10 @@ trait CommandImplicits {
   implicit def stringToCommandFilter(s: String) = CommandFilterMagnet {
     val target = s.trim().stripPrefix("/")
 
-    require(target.matches("""\w+"""))
+    // see https://www.regular-expressions.info/unicode.html
+    // \p{S} or \p{Symbol}: math symbols, currency signs, dingbats, box-drawing characters, etc. => Works for emoji
+    // \p{L} or \p{Symbol}: any kind of letter from any language.
+    require(target.matches("""[\p{L}|\p{S}]+"""))
 
     PartialFunction.cond(_) {
       case Command(cmd, _) if target.equalsIgnoreCase(cmd) => true

--- a/core/src/com/bot4s/telegram/models/BotCommand.scala
+++ b/core/src/com/bot4s/telegram/models/BotCommand.scala
@@ -4,9 +4,14 @@ package com.bot4s.telegram.models
  * This object represents a bot command.
  *
  *  @param command 	String 	Text of the command, 1-32 characters. Can contain only lowercase English letters, digits and underscores.
- *  @param description 	String 	Description of the command, 3-256 characters.
+ *  @param description 	String 	Description of the command, 1-256 characters.
  */
-case class BotCommand(
+case class BotCommand private (
   command: String,
   description: String
 )
+
+object BotCommand {
+  def apply(command: String, description: String) =
+    new BotCommand(command.toLowerCase().take(32), description.take(256))
+}

--- a/core/test/src/com/bot4s/telegram/api/CommandsSuite.scala
+++ b/core/test/src/com/bot4s/telegram/api/CommandsSuite.scala
@@ -20,6 +20,7 @@ class CommandsSuite extends AnyFlatSpec with MockFactory with TestUtils with Com
   trait Fixture {
     val handler           = mockFunction[Message, Future[Unit]]
     val handlerHello      = mockFunction[Message, Future[Unit]]
+    val handlerMetro      = mockFunction[Message, Future[Unit]]
     val handlerHelloWorld = mockFunction[Message, Future[Unit]]
     val handlerRespect    = mockFunction[Message, Future[Unit]]
 
@@ -39,6 +40,7 @@ class CommandsSuite extends AnyFlatSpec with MockFactory with TestUtils with Com
         }
       }
 
+      onCommand("/🚇")(handlerMetro)
       onCommand("/hello")(handlerHello)
       onCommand("/helloWorld")(handlerHelloWorld)
       onCommand("/respect" & RespectRecipient)(handlerRespect)
@@ -69,6 +71,18 @@ class CommandsSuite extends AnyFlatSpec with MockFactory with TestUtils with Com
       _ <- bot.receiveExtMessage((textMessage("/b"), None))
       _ <- bot.receiveExtMessage((textMessage("/c"), None))
     } yield ()).get
+  }
+
+  it should "support unicode" in new Fixture {
+    val m = textMessage("/🚇")
+    handlerMetro.expects(m).returning(Future.successful(())).once()
+    bot.receiveExtMessage((m, None)).get
+  }
+
+  it should "support unicode (2)" in new Fixture {
+    val m = textMessage("   /🚇 ")
+    handlerMetro.expects(m).returning(Future.successful(())).once()
+    bot.receiveExtMessage((m, None)).get
   }
 
   it should "support @sender suffix" in new Fixture {

--- a/examples/src/CommandsBot.scala
+++ b/examples/src/CommandsBot.scala
@@ -6,6 +6,8 @@ import com.bot4s.telegram.future.Polling
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Try
+import com.bot4s.telegram.methods.SetMyCommands
+import com.bot4s.telegram.models.BotCommand
 
 /**
  * Showcases different ways to declare commands (Commands + RegexCommands).
@@ -24,6 +26,17 @@ class CommandsBot(token: String)
   object Int {
     def unapply(s: String): Option[Int] = Try(s.toInt).toOption
   }
+
+  request(
+    SetMyCommands(
+      List(
+        BotCommand("hello", "Welcome someone"),
+        BotCommand("hola", "You guessed it"),
+        BotCommand("metro", "I'm late to work. Give me the train's schedule"),
+        BotCommand("Beer", "Let me see the menu")
+      )
+    )
+  ).void
 
   // String commands.
   onCommand("/hello") { implicit msg =>


### PR DESCRIPTION
This will ensure that the command is in lowercase and that the description is not too long.
This is not perfect as one could still use the copy construct to bypass those limitation, but the goal is to reduce the frustration of developers using the library (see https://github.com/bot4s/telegram/issues/190). Furthermore, the API does not give us a lot of details for invalid input, and it's pretty hard to guess what is going wrong.

This also fix the support for unicode characters in command (which is supposed to work but is probably broken for quite some time now). We might want to remove/update those regex in a future release