### PR TITLE
[api] Support v6.0

### DIFF
--- a/core/src/com/bot4s/telegram/api/RequestHandler.scala
+++ b/core/src/com/bot4s/telegram/api/RequestHandler.scala
@@ -7,6 +7,7 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.monadError._
 import com.bot4s.telegram.methods._
+import com.bot4s.telegram.models.MenuButton.menuButtonDecoder
 import io.circe.{ Decoder, Encoder }
 import com.typesafe.scalalogging.StrictLogging
 
@@ -46,6 +47,7 @@ abstract class RequestHandler[F[_]](implicit monadError: MonadError[F, Throwable
       // Pure JSON requests
       case s: ApproveChatJoinRequest          => sendRequest[R, ApproveChatJoinRequest](s)
       case s: AnswerCallbackQuery             => sendRequest[R, AnswerCallbackQuery](s)
+      case s: AnswerWebAppQuery               => sendRequest[R, AnswerWebAppQuery](s)
       case s: AnswerInlineQuery               => sendRequest[R, AnswerInlineQuery](s)
       case s: AnswerPreCheckoutQuery          => sendRequest[R, AnswerPreCheckoutQuery](s)
       case s: AnswerShippingQuery             => sendRequest[R, AnswerShippingQuery](s)
@@ -68,6 +70,7 @@ abstract class RequestHandler[F[_]](implicit monadError: MonadError[F, Throwable
       case s: GetChatMember                   => sendRequest[R, GetChatMember](s)
       case s: GetChatMemberCount              => sendRequest[R, GetChatMemberCount](s)
       case s: GetChatMembersCount             => sendRequest[R, GetChatMembersCount](s)
+      case s: GetChatMenuButton               => sendRequest[R, GetChatMenuButton](s)
       case s: GetFile                         => sendRequest[R, GetFile](s)
       case s: GetGameHighScores               => sendRequest[R, GetGameHighScores](s)
       case s: GetMe.type                      => sendRequest[R, GetMe.type](s)
@@ -94,6 +97,7 @@ abstract class RequestHandler[F[_]](implicit monadError: MonadError[F, Throwable
       case s: SendPoll                        => sendRequest[R, SendPoll](s)
       case s: SendVenue                       => sendRequest[R, SendVenue](s)
       case s: SetChatDescription              => sendRequest[R, SetChatDescription](s)
+      case s: SetChatMenuButton               => sendRequest[R, SetChatMenuButton](s)
       case s: SetChatAdministratorCustomTitle => sendRequest[R, SetChatAdministratorCustomTitle](s)
       case s: SetChatPermissions              => sendRequest[R, SetChatPermissions](s)
       case s: SetChatStickerSet               => sendRequest[R, SetChatStickerSet](s)

--- a/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
@@ -71,6 +71,10 @@ trait CirceDecoders extends StrictLogging {
   implicit val botCommandDecoder: Decoder[BotCommand] = deriveDecoder[BotCommand]
 
   implicit val chatLocationDecoder: Decoder[ChatLocation] = deriveDecoder[ChatLocation]
+  // for v6.0 support
+  implicit val webAppInfoDecoder: Decoder[WebAppInfo]                   = deriveDecoder[WebAppInfo]
+  implicit val webAppDataDecoder: Decoder[WebAppData]                   = deriveDecoder[WebAppData]
+  implicit val chatAdminRightsDecoder: Decoder[ChatAdministratorRights] = deriveDecoder[ChatAdministratorRights]
   // for v5.1 support
   implicit val chatInviteLinkDecoder: Decoder[ChatInviteLink]       = deriveDecoder[ChatInviteLink]
   implicit val chatMemberUpdatedDecoder: Decoder[ChatMemberUpdated] = deriveDecoder[ChatMemberUpdated]
@@ -81,6 +85,8 @@ trait CirceDecoders extends StrictLogging {
 
   implicit val chatDecoder: Decoder[Chat]           = deriveDecoder[Chat]
   implicit val chatPhotoDecoder: Decoder[ChatPhoto] = deriveDecoder[ChatPhoto]
+
+  implicit val KeyboardButtonPollTypeDecoder: Decoder[KeyboardButtonPollType] = deriveDecoder[KeyboardButtonPollType]
 
   implicit val contactDecoder: Decoder[Contact]                           = deriveDecoder[Contact]
   implicit val documentDecoder: Decoder[Document]                         = deriveDecoder[Document]

--- a/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
@@ -126,6 +126,11 @@ trait CirceDecoders extends StrictLogging {
   implicit val videoDecoder: Decoder[Video]                         = deriveDecoder[Video]
   implicit val videoNoteDecoder: Decoder[VideoNote]                 = deriveDecoder[VideoNote]
   implicit val voiceDecoder: Decoder[Voice]                         = deriveDecoder[Voice]
+  implicit val videoChatEndedDecoder: Decoder[VideoChatEnded]       = deriveDecoder[VideoChatEnded]
+  implicit val videoChatParticipantsInvitedDecoder: Decoder[VideoChatParticipantsInvited] =
+    deriveDecoder[VideoChatParticipantsInvited]
+  implicit val videoChatScheduledDecoder: Decoder[VideoChatScheduled]  = deriveDecoder[VideoChatScheduled]
+  implicit val videoChatStartedDecoder: Decoder[VideoChatStarted.type] = deriveDecoder[VideoChatStarted.type]
 
   implicit val gameHighScoreDecoder: Decoder[GameHighScore] = deriveDecoder[GameHighScore]
   implicit val animationDecoder: Decoder[Animation]         = deriveDecoder[Animation]

--- a/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
@@ -16,10 +16,9 @@ import com.bot4s.telegram.models.BotCommandScope.BotCommandScope
 import com.bot4s.telegram.models.MessageEntityType.MessageEntityType
 import UpdateType.UpdateType
 import com.bot4s.telegram.models._
-import io.circe.Decoder
+import io.circe.{ Decoder, HCursor }
 import io.circe.generic.semiauto._
 import com.typesafe.scalalogging.StrictLogging
-import io.circe.HCursor
 
 /**
  * Circe marshalling borrowed/inspired from [[https://github.com/nikdon/telepooz]]
@@ -75,6 +74,7 @@ trait CirceDecoders extends StrictLogging {
   implicit val webAppInfoDecoder: Decoder[WebAppInfo]                   = deriveDecoder[WebAppInfo]
   implicit val webAppDataDecoder: Decoder[WebAppData]                   = deriveDecoder[WebAppData]
   implicit val chatAdminRightsDecoder: Decoder[ChatAdministratorRights] = deriveDecoder[ChatAdministratorRights]
+  implicit val sentWebAppMessageDecoder: Decoder[SentWebAppMessage]     = deriveDecoder[SentWebAppMessage]
   // for v5.1 support
   implicit val chatInviteLinkDecoder: Decoder[ChatInviteLink]       = deriveDecoder[ChatInviteLink]
   implicit val chatMemberUpdatedDecoder: Decoder[ChatMemberUpdated] = deriveDecoder[ChatMemberUpdated]
@@ -183,6 +183,7 @@ trait CirceDecoders extends StrictLogging {
     val r: Decoder[Either[A, B]] = decB.map(Right.apply)
     l or r
   }
+
 }
 
 object CirceDecoders extends CirceDecoders

--- a/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
@@ -214,6 +214,23 @@ trait CirceEncoders {
 
   implicit val answerInlineQueryEncoder: Encoder[AnswerInlineQuery] = deriveConfiguredEncoder[AnswerInlineQuery]
 
+  // MenuButton
+
+  implicit val menuButtonDefaultEncoder: Encoder[MenuButtonDefault] =
+    deriveConfiguredEncoder[MenuButtonDefault]
+
+  implicit val menuButtonWebAppEncoder: Encoder[MenuButtonWebApp] =
+    deriveConfiguredEncoder[MenuButtonWebApp]
+
+  implicit val menuButtonCommandsEncoder: Encoder[MenuButtonCommands] =
+    deriveConfiguredEncoder[MenuButtonCommands]
+
+  implicit val menuButtonEncoder: Encoder[MenuButton] = Encoder.instance {
+    case q: MenuButtonDefault  => q.asJson
+    case q: MenuButtonWebApp   => q.asJson
+    case q: MenuButtonCommands => q.asJson
+  }
+
   // Methods
   implicit val getMeEncoder: Encoder[GetMe.type]                   = Encoder.instance(_ => io.circe.Json.Null)
   implicit val deleteWebhookEncoder: Encoder[DeleteWebhook.type]   = Encoder.instance(_ => io.circe.Json.Null)
@@ -230,10 +247,12 @@ trait CirceEncoders {
 
   implicit val chatLocationEncoder: Encoder[ChatLocation] = deriveConfiguredEncoder[ChatLocation]
   // for v6.0 support
-  implicit val webAppInfoEncoder: Encoder[WebAppInfo] = deriveEncoder[WebAppInfo]
-  implicit val webAppDataEncoder: Encoder[WebAppData] = deriveEncoder[WebAppData]
+  implicit val webAppInfoEncoder: Encoder[WebAppInfo] = deriveConfiguredEncoder[WebAppInfo]
+  implicit val webAppDataEncoder: Encoder[WebAppData] = deriveConfiguredEncoder[WebAppData]
   implicit val chatAdminRightsEncoder: Encoder[ChatAdministratorRights] =
     deriveConfiguredEncoder[ChatAdministratorRights]
+  implicit val answerWebAppQueryEncoder: Encoder[AnswerWebAppQuery] = deriveConfiguredEncoder[AnswerWebAppQuery]
+  implicit val sentWebAppMessageEncoder: Encoder[SentWebAppMessage] = deriveConfiguredEncoder[SentWebAppMessage]
 
   // for v5.1 support
   implicit val chatInviteLinkEncoder: Encoder[ChatInviteLink]       = deriveConfiguredEncoder[ChatInviteLink]
@@ -295,6 +314,7 @@ trait CirceEncoders {
   implicit val getChatMemberCountEncoder: Encoder[GetChatMemberCount]   = deriveConfiguredEncoder[GetChatMemberCount]
   implicit val getChatMembersCountEncoder: Encoder[GetChatMembersCount] = deriveConfiguredEncoder[GetChatMembersCount]
   implicit val getChatMemberEncoder: Encoder[GetChatMember]             = deriveConfiguredEncoder[GetChatMember]
+  implicit val getChatMenuButtonEncoder: Encoder[GetChatMenuButton]     = deriveConfiguredEncoder[GetChatMenuButton]
   implicit val answerCallbackQueryEncoder: Encoder[AnswerCallbackQuery] = deriveConfiguredEncoder[AnswerCallbackQuery]
 
   implicit val editMessageTextEncoder: Encoder[EditMessageText]       = deriveConfiguredEncoder[EditMessageText]
@@ -333,7 +353,8 @@ trait CirceEncoders {
 
   implicit val setChatStickerSetEncoder: Encoder[SetChatStickerSet] = deriveConfiguredEncoder[SetChatStickerSet]
 
-  implicit val setChatTitleEncoder: Encoder[SetChatTitle] = deriveConfiguredEncoder[SetChatTitle]
+  implicit val setChatTitleEncoder: Encoder[SetChatTitle]       = deriveConfiguredEncoder[SetChatTitle]
+  implicit val setChatButtonEncoder: Encoder[SetChatMenuButton] = deriveConfiguredEncoder[SetChatMenuButton]
 
   implicit val setStickerPositionInSetEncoder: Encoder[SetStickerPositionInSet] =
     deriveConfiguredEncoder[SetStickerPositionInSet]

--- a/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
@@ -229,6 +229,12 @@ trait CirceEncoders {
   implicit val getUpdatesEncoder: Encoder[GetUpdates]         = deriveConfiguredEncoder[GetUpdates]
 
   implicit val chatLocationEncoder: Encoder[ChatLocation] = deriveConfiguredEncoder[ChatLocation]
+  // for v6.0 support
+  implicit val webAppInfoEncoder: Encoder[WebAppInfo] = deriveEncoder[WebAppInfo]
+  implicit val webAppDataEncoder: Encoder[WebAppData] = deriveEncoder[WebAppData]
+  implicit val chatAdminRightsEncoder: Encoder[ChatAdministratorRights] =
+    deriveConfiguredEncoder[ChatAdministratorRights]
+
   // for v5.1 support
   implicit val chatInviteLinkEncoder: Encoder[ChatInviteLink]       = deriveConfiguredEncoder[ChatInviteLink]
   implicit val chatMemberUpdatedEncoder: Encoder[ChatMemberUpdated] = deriveConfiguredEncoder[ChatMemberUpdated]

--- a/core/src/com/bot4s/telegram/methods/AnswerWebAppQuery.scala
+++ b/core/src/com/bot4s/telegram/methods/AnswerWebAppQuery.scala
@@ -1,0 +1,14 @@
+package com.bot4s.telegram.methods
+
+import com.bot4s.telegram.models.{ InlineQueryResult, SentWebAppMessage }
+
+/**
+ * Use this method to set the result of an interaction with a Web App and send a corresponding message on behalf of the user to the chat from which the query originated. On success, a SentWebAppMessage object is returned.
+ *
+ * @param webAppQueryId   Unique identifier for the query to be answered
+ * @param result           	A JSON-serialized object describing the message to be sent
+ */
+case class AnswerWebAppQuery(
+  webAppQueryId: String,
+  result: Option[InlineQueryResult] = None
+) extends JsonRequest[SentWebAppMessage]

--- a/core/src/com/bot4s/telegram/methods/GetChatMenuButton.scala
+++ b/core/src/com/bot4s/telegram/methods/GetChatMenuButton.scala
@@ -1,0 +1,13 @@
+package com.bot4s.telegram.methods
+
+import com.bot4s.telegram.models.{ ChatId, MenuButton }
+
+/**
+ * Use this method to get the current value of the bot's menu button in a private chat, or the default menu button.
+ * Returns MenuButton on success.
+ *
+ * @param chatId      Integer or String Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+ */
+case class GetChatMenuButton(
+  chatId: ChatId
+) extends JsonRequest[MenuButton]

--- a/core/src/com/bot4s/telegram/methods/GetMyDefaultAdministratorRights.scala
+++ b/core/src/com/bot4s/telegram/methods/GetMyDefaultAdministratorRights.scala
@@ -1,0 +1,13 @@
+package com.bot4s.telegram.methods
+
+import com.bot4s.telegram.models.ChatAdministratorRights
+
+/**
+ * Use this method to get the current default administrator rights of the bot. Returns ChatAdministratorRights on success.
+ *
+ * @param forChannels Optional Boolean. Pass True to change the default administrator rights of the bot in channels.
+ *                    Otherwise, the default administrator rights of the bot for groups and supergroups will be changed.
+ */
+case class GetMyDefaultAdministratorRights(
+  forChannels: Option[Boolean] = None
+) extends JsonRequest[ChatAdministratorRights]

--- a/core/src/com/bot4s/telegram/methods/PromoteChatMember.scala
+++ b/core/src/com/bot4s/telegram/methods/PromoteChatMember.scala
@@ -11,11 +11,16 @@ import com.bot4s.telegram.models.ChatId
  * @param chatId              Integer or String Unique identifier for the target chat or username of the target channel
  *                            (in the format @channelusername)
  * @param userId              Long Unique identifier of the target user
+ * @param isAnonymous         Boolean Optional Pass True, if the administrator's presence in the chat is hidden
+ * @param canManageChat       Boolean Optional Pass True, if the administrator can access the chat event log,
+ *                            chat statistics, message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode.
+ *                            Implied by any other administrator privilege
  * @param canChangeInfo       Boolean Optional Pass True, if the administrator can change chat title, photo and other settings
  * @param canPostMessages     Boolean Optional Pass True, if the administrator can create channel posts, channels only
  * @param canEditMessages     Boolean Optional Pass True, if the administrator can edit messages of other users, channels only
  * @param canDeleteMessages   Boolean Optional Pass True, if the administrator can delete messages of other users
  * @param canInviteUsers      Boolean Optional Pass True, if the administrator can invite new users to the chat
+ * @param canManageVideoChats Boolean Optional Pass True, if the administrator can manage video chats
  * @param canRestrictMembers  Boolean Optional Pass True, if the administrator can restrict, ban or unban chat members
  * @param canPinMessages      Boolean Optional Pass True, if the administrator can pin messages, supergroups only
  * @param canPromoteMembers   Boolean Optional Pass True, if the administrator can add new administrators with a subset
@@ -25,11 +30,14 @@ import com.bot4s.telegram.models.ChatId
 case class PromoteChatMember(
   chatId: ChatId,
   userId: Long,
+  isAnonymous: Option[Boolean] = None,
+  canManageChat: Option[Boolean] = None,
   canChangeInfo: Option[Boolean] = None,
   canPostMessages: Option[Boolean] = None,
   canEditMessages: Option[Boolean] = None,
   canDeleteMessages: Option[Boolean] = None,
   canInviteUsers: Option[Boolean] = None,
+  canManageVideoChats: Option[Boolean] = None,
   canRestrictMembers: Option[Boolean] = None,
   canPinMessages: Option[Boolean] = None,
   canPromoteMembers: Option[Boolean] = None

--- a/core/src/com/bot4s/telegram/methods/SetChatMenuButton.scala
+++ b/core/src/com/bot4s/telegram/methods/SetChatMenuButton.scala
@@ -1,0 +1,14 @@
+package com.bot4s.telegram.methods
+
+import com.bot4s.telegram.models.{ ChatId, MenuButton, MenuButtonDefault }
+
+/**
+ * Use this method to change the bot's menu button in a private chat, or the default menu button. Returns True on success.
+ *
+ * @param chatId 	      Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+ * @param menuButton 	  A JSON-serialized object for the bot's new menu button. Defaults to MenuButtonDefault
+ */
+case class SetChatMenuButton(
+  chatId: ChatId,
+  menuButton: Option[MenuButton] = Some(MenuButtonDefault())
+) extends JsonRequest[Boolean]

--- a/core/src/com/bot4s/telegram/methods/SetMyDefaultAdministratorRights.scala
+++ b/core/src/com/bot4s/telegram/methods/SetMyDefaultAdministratorRights.scala
@@ -1,0 +1,18 @@
+package com.bot4s.telegram.methods
+
+import com.bot4s.telegram.models.ChatAdministratorRights
+
+/**
+ *  Use this method to change the default administrator rights requested by the bot when it's added as an administrator to groups or channels.
+ *  These rights will be suggested to users, but they are are free to modify the list before adding the bot.
+ *  Returns True on success.
+ *
+ * @param rights      Optional ChatAdministratorRights. A JSON-serialized object describing new default administrator rights.
+ *                    If not specified, the default administrator rights will be cleared.
+ * @param forChannels Optional Boolean. Pass True to change the default administrator rights of the bot in channels.
+ *                    Otherwise, the default administrator rights of the bot for groups and supergroups will be changed.
+ */
+case class SetMyDefaultAdministratorRights(
+  rights: Option[ChatAdministratorRights] = None,
+  forChannels: Option[Boolean] = None
+) extends JsonRequest[Boolean]

--- a/core/src/com/bot4s/telegram/models/ChatAdministratorRights.scala
+++ b/core/src/com/bot4s/telegram/models/ChatAdministratorRights.scala
@@ -1,0 +1,36 @@
+package com.bot4s.telegram.models
+
+/**
+ * Represents the rights of an administrator in a chat.
+ *
+ * @param isAnonymous         Boolean True, if the user's presence in the chat is hidden
+ * @param canManageChat       Boolean True, if the administrator can access the chat event log, chat statistics, message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode. Implied by any other administrator privilege
+ * @param canDeleteMessages   Boolean True, if the administrator can delete messages of other users
+ * @param canManageVideoChats Boolean True, if the administrator can manage video chats
+ * @param canRestrictMembers  Boolean True, if the administrator can restrict, ban or unban chat members
+ * @param canPromoteMembers   Boolean True, if the administrator can add new administrators with a subset of their own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user)
+ * @param canChangeInfo       Boolean True, if the user is allowed to change the chat title, photo and other settings
+ * @param canInviteUsers      Boolean True, if the user is allowed to invite new users to the chat
+ * @param canPostMessages     Boolean Optional. True, if the administrator can post in the channel; channels only
+ * @param canEditMessages     Boolean Optional. True, if the administrator can edit messages of other users and can pin messages; channels only
+ * @param canPinMessages      Boolean Optional. True, if the user is allowed to pin messages; groups and supergroups only
+ * @param from                Performer of the action, which resulted in the change
+ * @param date                Date the change was done in Unix time
+ * @param chat                Chat the user belongs to
+ * @param oldChatMember       Previous information about the chat member
+ * @param newChatMember       New information about the chat member
+ * @param inviteLink          Optional. Chat invite link, which was used by the user to join the chat; for joining by invite link events only.
+ */
+case class ChatAdministratorRights(
+  isAnonymous: Boolean,
+  canManageChat: Boolean,
+  canDeleteMessages: Boolean,
+  canManageVideoChats: Boolean,
+  canRestrictMembers: Boolean,
+  canPromoteMembers: Boolean,
+  canChangeInfo: Boolean,
+  canInviteUsers: Boolean,
+  canPostMessages: Option[Boolean],
+  canEditMessages: Option[Boolean],
+  canPinMessages: Option[Boolean]
+)

--- a/core/src/com/bot4s/telegram/models/ChatMember.scala
+++ b/core/src/com/bot4s/telegram/models/ChatMember.scala
@@ -7,22 +7,23 @@ import MemberStatus.MemberStatus
  *
  * @param user                   User Information about the user
  * @param status                 String The member's status in the chat. Can be "creator", "administrator", "member", "left" or "kicked"
- * @param untilDate              Integer	Optional. Restricted and kicked only. Date when restrictions will be lifted for this user, unix time
- * @param canBeEdited            Boolean	Optional. Administrators only. True, if the bot is allowed to edit administrator privileges of that user
- * @param canChangeInfo          Boolean	Optional.  Administrators and restricted only. True, if the user is allowed to change the chat title, photo and other settings
- * @param canPostMessages        Boolean	Optional. Administrators only. True, if the administrator can post in the channel, channels only
- * @param canEditMessages        Boolean	Optional. Administrators only. True, if the administrator can edit messages of other users, channels only
- * @param canDeleteMessages      Boolean	Optional. Administrators only. True, if the administrator can delete messages of other users
- * @param canInviteUsers         Boolean	Optional. Administrators and restricted only. True, if the user is allowed to invite new users to the chat
- * @param canRestrictMembers     Boolean	Optional. Administrators only. True, if the administrator can restrict, ban or unban chat members
- * @param canPinMessages         Boolean	Optional. Administrators and restricted only. True, if the user is allowed to pin messages; groups and supergroups only
- * @param canPromoteMembers      Boolean	Optional. Administrators only. True, if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user)
+ * @param untilDate              Integer Optional. Restricted and kicked only. Date when restrictions will be lifted for this user, unix time
+ * @param canBeEdited            Boolean Optional. Administrators only. True, if the bot is allowed to edit administrator privileges of that user
+ * @param canChangeInfo          Boolean Optional.  Administrators and restricted only. True, if the user is allowed to change the chat title, photo and other settings
+ * @param canPostMessages        Boolean Optional. Administrators only. True, if the administrator can post in the channel, channels only
+ * @param canEditMessages        Boolean Optional. Administrators only. True, if the administrator can edit messages of other users, channels only
+ * @param canDeleteMessages      Boolean Optional. Administrators only. True, if the administrator can delete messages of other users
+ * @param canInviteUsers         Boolean Optional. Administrators and restricted only. True, if the user is allowed to invite new users to the chat
+ * @param canRestrictMembers     Boolean Optional. Administrators only. True, if the administrator can restrict, ban or unban chat members
+ * @param canPinMessages         Boolean Optional. Administrators and restricted only. True, if the user is allowed to pin messages; groups and supergroups only
+ * @param canPromoteMembers      Boolean Optional. Administrators only. True, if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user)
  * @param isMember               Boolean Optional. Restricted only. True, if the user is a member of the chat at the moment of the request
- * @param canSendMessages        Boolean	Optional. Restricted only. True, if the user can send text messages, contacts, locations and venues
- * @param canSendMediaMessages   Boolean	Optional. Restricted only. True, if the user can send audios, documents, photos, videos, video notes and voice notes, implies can_send_messages
+ * @param canSendMessages        Boolean Optional. Restricted only. True, if the user can send text messages, contacts, locations and venues
+ * @param canSendMediaMessages   Boolean Optional. Restricted only. True, if the user can send audios, documents, photos, videos, video notes and voice notes, implies can_send_messages
  * @param canSendPolls           Boolean Optional. Restricted only. True, if the user is allowed to send polls
- * @param canSendOtherMessages   Boolean	Optional. Restricted only. True, if the user can send animations, games, stickers and use inline bots, implies can_send_media_messages
- * @param canAddWebPagePreviews  Boolean	Optional. Restricted only. True, if user may add web page previews to his messages, implies can_send_media_messages
+ * @param canSendOtherMessages   Boolean Optional. Restricted only. True, if the user can send animations, games, stickers and use inline bots, implies can_send_media_messages
+ * @param canAddWebPagePreviews  Boolean Optional. Restricted only. True, if user may add web page previews to his messages, implies can_send_media_messages
+ * @param canManageVideoChats    Boolean Optional. if the administrator can manage video chats
  */
 case class ChatMember(
   user: User,
@@ -42,5 +43,6 @@ case class ChatMember(
   canSendMediaMessages: Option[Boolean] = None,
   canSendPolls: Option[Boolean] = None,
   canSendOtherMessages: Option[Boolean] = None,
-  canAddWebPagePreviews: Option[Boolean] = None
+  canAddWebPagePreviews: Option[Boolean] = None,
+  canManageVideoChats: Option[Boolean] = None
 )

--- a/core/src/com/bot4s/telegram/models/MenuButton.scala
+++ b/core/src/com/bot4s/telegram/models/MenuButton.scala
@@ -1,0 +1,64 @@
+package com.bot4s.telegram.models
+
+/**
+ * This object describes the bot's menu button in a private chat. It should be one of
+ *
+ *   MenuButtonCommands
+ *   MenuButtonWebApp
+ *   MenuButtonDefault
+ */
+sealed trait MenuButton {
+  def `type`: String
+}
+
+/**
+ * Represents a menu button, which opens the bot's list of commands.
+ *
+ * @param type                 String Type of the button, must be commands
+ */
+case class MenuButtonCommands(
+  `type`: String = "commands"
+) extends MenuButton
+
+/**
+ * Represents a menu button, which launches a Web App.
+ *
+ * @param type         String Type of the result, must be photo
+ * @param text         String Text on the button
+ * @param webApp       Description of the Web App that will be launched when the user presses the button.
+ *                     The Web App will be able to send an arbitrary message on behalf of the user using the method answerWebAppQuery.
+ */
+case class MenuButtonWebApp(
+  `type`: String = "web_app",
+  text: String,
+  webApp: WebAppInfo
+) extends MenuButton
+
+/**
+ * Describes that no specific value for the menu button was set.
+ *
+ * @param type           String Type of the result, must be game
+ */
+case class MenuButtonDefault(
+  `type`: String = "default"
+) extends MenuButton
+
+object MenuButton {
+  import io.circe.Decoder
+  import io.circe.generic.extras.semiauto._
+  import io.circe.generic.extras.Configuration
+  import com.bot4s.telegram.marshalling.CirceDecoders._
+
+  private implicit val configuration: Configuration = Configuration.default.withSnakeCaseMemberNames
+    .withDiscriminator("type")
+    .copy(
+      transformConstructorNames = {
+        case "MenuButtonCommands" => "commands"
+        case "MenuButtonWebApp"   => "web_app"
+        case "MenuButtonDefault"  => "default"
+      }
+    )
+
+  implicit val menuButtonDecoder: Decoder[MenuButton] =
+    deriveConfiguredDecoder[MenuButton]
+}

--- a/core/src/com/bot4s/telegram/models/Message.scala
+++ b/core/src/com/bot4s/telegram/models/Message.scala
@@ -64,6 +64,7 @@ package com.bot4s.telegram.models
  * @param hasProtectedContent    Optional. True, if messages from the chat can't be forwarded to other chats. Returned only in getChat.
  * @param isAutomaticForward     Optional. True, if the message is a channel post that was automatically forwarded to the connected discussion group
  * @param senderChat             Optional. Sender of the message; empty for messages sent to channels. For backward compatibility, the field contains a fake sender user in non-channel chats, if the message was sent on behalf of a chat.
+ * @param webAppData 	           WebAppData 	Optional. Service message: data sent by a Web App
  */
 case class Message(
   messageId: Int,
@@ -113,8 +114,9 @@ case class Message(
   replyMarkup: Option[InlineKeyboardMarkup] = None,
   hasProtectedContent: Option[Boolean] = None,
   isAutomaticForward: Option[Boolean] = None,
-  senderChat: Option[Chat] = None
+  senderChat: Option[Chat] = None,
+  webAppData: Option[WebAppData] = None
 ) {
 
-  def source: Long = chat.id // ChatId.Chat(chat.id)
+  def source: Long = chat.id
 }

--- a/core/src/com/bot4s/telegram/models/Message.scala
+++ b/core/src/com/bot4s/telegram/models/Message.scala
@@ -115,7 +115,11 @@ case class Message(
   hasProtectedContent: Option[Boolean] = None,
   isAutomaticForward: Option[Boolean] = None,
   senderChat: Option[Chat] = None,
-  webAppData: Option[WebAppData] = None
+  webAppData: Option[WebAppData] = None,
+  videoChatScheduled: Option[VideoChatScheduled] = None,
+  videoChatStarted: Option[VideoChatStarted.type] = None,
+  videoChatEnded: Option[VideoChatEnded] = None,
+  videoChatParticipantsInvited: Option[VideoChatParticipantsInvited] = None
 ) {
 
   def source: Long = chat.id

--- a/core/src/com/bot4s/telegram/models/ReplyMarkup.scala
+++ b/core/src/com/bot4s/telegram/models/ReplyMarkup.scala
@@ -18,15 +18,21 @@ sealed trait ReplyMarkup
  *
  * @param text             String Text of the button. If none of the optional fields are used, it will be sent to the
  *                         bot as a message when the button is pressed
- * @param requestContact   Boolean Optional If True, the user's phone number will be sent as a contact when the button
+ * @param requestContact   Boolean Optional. If True, the user's phone number will be sent as a contact when the button
  *                         is pressed. Available in private chats only
- * @param requestLocation  Boolean Optional If True, the user's current location will be sent when the button is pressed.
+ * @param requestLocation  Boolean Optional. If True, the user's current location will be sent when the button is pressed.
  *                         Available in private chats only
+ * @param requestPoll      KeyboardButtonPollType Optional. If specified, the user will be asked to create a poll and send it to the bot when the button is pressed.
+ *                         Available in private chats only.
+ * @param webApp           WebAppInfo Optional. If specified, the described Web App will be launched when the button is pressed.
+ *                         The Web App will be able to send a “web_app_data” service message. Available in private chats only.
  */
 case class KeyboardButton(
   text: String,
   requestContact: Option[Boolean] = None,
-  requestLocation: Option[Boolean] = None
+  requestLocation: Option[Boolean] = None,
+  requestPoll: Option[KeyboardButtonPollType] = None,
+  webApp: Option[WebAppInfo] = None
 ) /* not a ReplyMarkup */
 
 /**
@@ -205,6 +211,8 @@ object InlineKeyboardMarkup {
  * @param url                String Optional HTTP url to be opened when button is pressed
  * @param loginUrl           LoginUrl Optional. An HTTP URL used to automatically authorize the user.
  *                           Can be used as a replacement for the Telegram Login Widget.
+ * @param webApp             WebAppInfo Optional. If specified, the described Web App will be launched when the button is pressed.
+ *                           The Web App will be able to send a “web_app_data” service message. Available in private chats only.
  * @param callbackData       String Optional Data to be sent in a callback query to the bot when button is pressed, 1-64 bytes
  * @param switchInlineQuery  String Optional If set, pressing the button will prompt the user to select one of their chats,
  *                           open that chat and insert the bot's username and the specified inline query in the input field.
@@ -223,6 +231,7 @@ case class InlineKeyboardButton(
   callbackData: Option[String] = None,
   url: Option[String] = None,
   loginUrl: Option[LoginUrl] = None,
+  webApp: Option[WebAppInfo] = None,
   switchInlineQuery: Option[String] = None,
   switchInlineQueryCurrentChat: Option[String] = None,
   callbackGame: Option[CallbackGame] = None,
@@ -329,3 +338,14 @@ case class ForceReply(
   inputFieldPlaceholder: Option[String] = None,
   selective: Option[Boolean] = None
 ) extends ReplyMarkup
+
+/**
+ * This object represents type of a poll, which is allowed to be created and sent when the corresponding button is pressed.
+ *
+ * @param `type` String Optional. If quiz is passed, the user will be allowed to create only polls in the quiz mode.
+ *               If regular is passed, only regular polls will be allowed.
+ *               Otherwise, the user will be allowed to create a poll of any type.
+ */
+case class KeyboardButtonPollType(
+  `type`: Option[String] = None
+)

--- a/core/src/com/bot4s/telegram/models/SentWebAppMessage.scala
+++ b/core/src/com/bot4s/telegram/models/SentWebAppMessage.scala
@@ -1,0 +1,10 @@
+package com.bot4s.telegram.models
+
+/**
+ * This object represents one shipping option.
+ *
+ * @param inlineMessageId     Optional. Identifier of the sent inline message. Available only if there is an inline keyboard attached to the message.
+ */
+case class SentWebAppMessage(
+  inlineMessageId: Option[String] = None
+)

--- a/core/src/com/bot4s/telegram/models/VideoChatEnded.scala
+++ b/core/src/com/bot4s/telegram/models/VideoChatEnded.scala
@@ -1,0 +1,10 @@
+package com.bot4s.telegram.models
+
+/**
+ * This object represents a service message about a video chat ended in the chat.
+ *
+ * @param duration
+ */
+case class VideoChatEnded(
+  duration: Int
+)

--- a/core/src/com/bot4s/telegram/models/VideoChatParticipantsInvited.scala
+++ b/core/src/com/bot4s/telegram/models/VideoChatParticipantsInvited.scala
@@ -1,0 +1,10 @@
+package com.bot4s.telegram.models
+
+/**
+ * This object represents a service message about new members invited to a video chat.
+ *
+ * @param users  New members that were invited to the video chat
+ */
+case class VideoChatParticipantsInvited(
+  users: Array[User]
+)

--- a/core/src/com/bot4s/telegram/models/VideoChatScheduled.scala
+++ b/core/src/com/bot4s/telegram/models/VideoChatScheduled.scala
@@ -1,0 +1,10 @@
+package com.bot4s.telegram.models
+
+/**
+ * This object represents a service message about a video chat scheduled in the chat.
+ *
+ * @param startDate  Point in time (Unix timestamp) when the video chat is supposed to be started by a chat administrator
+ */
+case class VideoChatScheduled(
+  startDate: Int
+)

--- a/core/src/com/bot4s/telegram/models/VideoChatStarted.scala
+++ b/core/src/com/bot4s/telegram/models/VideoChatStarted.scala
@@ -1,0 +1,6 @@
+package com.bot4s.telegram.models
+
+/**
+ * This object represents a service message about a video chat started in the chat. Currently holds no information.
+ */
+case object VideoChatStarted

--- a/core/src/com/bot4s/telegram/models/WebAppData.scala
+++ b/core/src/com/bot4s/telegram/models/WebAppData.scala
@@ -1,0 +1,12 @@
+package com.bot4s.telegram.models
+
+/**
+ * Contains data sent from a Web App to the bot.
+ *
+ * @param data String. Be aware that a bad client can send arbitrary data in this field.
+ * @param buttonText String. Text of the web_app keyboard button, from which the Web App was opened. Be aware that a bad client can send arbitrary data in this field.
+ */
+case class WebAppData(
+  data: String,
+  buttonText: String
+)

--- a/core/src/com/bot4s/telegram/models/WebAppInfo.scala
+++ b/core/src/com/bot4s/telegram/models/WebAppInfo.scala
@@ -1,0 +1,10 @@
+package com.bot4s.telegram.models
+
+/**
+ * Contains information about a Web App.
+ *
+ * @param url String. An HTTPS URL of a Web App to be opened with additional data as specified in Initializing Web Apps
+ */
+case class WebAppInfo(
+  url: String
+)

--- a/core/src/com/bot4s/telegram/models/WebhookInfo.scala
+++ b/core/src/com/bot4s/telegram/models/WebhookInfo.scala
@@ -3,16 +3,24 @@ package com.bot4s.telegram.models
 /**
  * Contains information about the current status of a webhook.
  *
- * @param url                   Webhook URL, may be empty if webhook is not set up
- * @param hasCustomCertificate  True, if a custom certificate was provided for webhook certificate checks
- * @param pendingUpdateCount    Number of updates awaiting delivery
- * @param lastErrorDate         Optional. Unix time for the most recent error that happened when trying to deliver an update via webhook
- * @param lastErrorMessage      Optional. Error message in human-readable format for the most recent error that happened when trying to deliver an update via webhook
+ * @param url                           Webhook URL, may be empty if webhook is not set up
+ * @param hasCustomCertificate          True, if a custom certificate was provided for webhook certificate checks
+ * @param pendingUpdateCount            Number of updates awaiting delivery
+ * @param ipAddress                     String Optional. Currently used webhook IP address
+ * @param lastErrorDate                 Optional. Unix time for the most recent error that happened when trying to deliver an update via webhook
+ * @param lastErrorMessage              Optional. Error message in human-readable format for the most recent error that happened when trying to deliver an update via webhook
+ * @param lastSynchronizationErrorDate  Optional. Unix time for the most recent error that happened when trying to synchronize the webhook with Telegram datacenter
+ * @param maxConnections                Optional. Integer. Maximum allowed number of simultaneous HTTPS connections to the webhook for update delivery
+ * @param allowedUpdates                Optional. Array of String. A list of update types the bot is subscribed to. Defaults to all update types except chat_member
  */
 case class WebhookInfo(
   url: String,
   hasCustomCertificate: Boolean,
   pendingUpdateCount: Int,
+  ipAddress: Option[String] = None,
   lastErrorDate: Option[Int] = None,
-  lastErrorMessage: Option[String] = None
+  lastErrorMessage: Option[String] = None,
+  lastSynchronizationErrorDate: Option[Int] = None,
+  maxConnections: Option[Int] = None,
+  allowedUpdates: Option[Array[String]] = None
 )

--- a/core/test/src/com/bot4s/telegram/marshalling/MarshallingSuite.scala
+++ b/core/test/src/com/bot4s/telegram/marshalling/MarshallingSuite.scala
@@ -122,4 +122,38 @@ class MarshallingSuite extends AnyFlatSpec with MockFactory with Matchers with T
     toJson[CallbackGame](CallbackGame) shouldBe """{}"""
     fromJson[CallbackGame]("""{}""") shouldBe CallbackGame
   }
+
+  it should "decode a menu button" in {
+    val json = """
+    {
+      "type": "default"
+    }"""
+    io.circe.parser.decode[MenuButton](json).toOption.get shouldBe MenuButtonDefault(`type` = "default")
+  }
+
+  it should "decode a web app menu button" in {
+    val json = """
+    {
+      "type": "web_app",
+      "text": "Application",
+      "web_app": {
+        "url": "http://test.com"
+      }
+    }"""
+    io.circe.parser.decode[MenuButton](json).toOption.get shouldBe MenuButtonWebApp(
+      `type` = "web_app",
+      text = "Application",
+      webApp = WebAppInfo(url = "http://test.com")
+    )
+  }
+
+  it should "decode a command menu button" in {
+    val json = """
+    {
+      "type": "commands"
+    }"""
+    io.circe.parser.decode[MenuButton](json).toOption.get shouldBe MenuButtonCommands(
+      `type` = "commands"
+    )
+  }
 }

--- a/examples/src/JoinRequestBot.scala
+++ b/examples/src/JoinRequestBot.scala
@@ -4,8 +4,6 @@ import com.bot4s.telegram.api.declarative.{ Commands, JoinRequests }
 
 import scala.concurrent.Future
 import com.bot4s.telegram.methods.CreateChatInviteLink
-import com.bot4s.telegram.methods.CreateChatInviteLink
-import com.bot4s.telegram.api.declarative._
 import com.bot4s.telegram.models._
 import com.bot4s.telegram.methods.ApproveChatJoinRequest
 import com.bot4s.telegram.methods.DeclineChatJoinRequest


### PR DESCRIPTION
 https://core.telegram.org/bots/api#april-16-2022

  - [x] Added support for Web Apps, see the detailed manual here. (blog announcement)
  - [x] Added the class WebAppInfo and the fields web_app to the classes KeyboardButton and InlineKeyboardButton.
  - [x] Added the class SentWebAppMessage and the method answerWebAppQuery for sending an answer to a Web App query, which originated from an inline button of the 'web_app' type.
  - [x] Added the class WebAppData and the field web_app_data to the class Message.
  - [x] Added the class MenuButton and the methods setChatMenuButton and getChatMenuButton for managing the behavior of the bot's menu button in private chats.
  - [x] Added the class ChatAdministratorRights and the methods setMyDefaultAdministratorRights and getMyDefaultAdministratorRights for managing the bot's default administrator rights.
  - [x] Added support for t.me links that can be used to add the bot to groups and channels as an administrator.
  - [x] Added the field last_synchronization_error_date to the class WebhookInfo.
  - [x] Renamed the field can_manage_voice_chats to can_manage_video_chats in the class ChatMemberAdministrator. The old field will remain temporarily available.
  - [x] Renamed the parameter can_manage_voice_chats to can_manage_video_chats in the method promoteChatMember. The old parameter will remain temporarily available.
  - [x] Renamed the fields voice_chat_scheduled, voice_chat_started, voice_chat_ended, and voice_chat_participants_invited to video_chat_scheduled, video_chat_started, video_chat_ended, and video_chat_participants_invited in the class Message. The old fields will remain temporarily available.