### PR TITLE
[api] Support v6.2

### DIFF
--- a/core/src/com/bot4s/telegram/api/RequestHandler.scala
+++ b/core/src/com/bot4s/telegram/api/RequestHandler.scala
@@ -7,7 +7,6 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.monadError._
 import com.bot4s.telegram.methods._
-import com.bot4s.telegram.models.MenuButton.menuButtonDecoder
 import io.circe.{ Decoder, Encoder }
 import com.typesafe.scalalogging.StrictLogging
 
@@ -72,6 +71,7 @@ abstract class RequestHandler[F[_]](implicit monadError: MonadError[F, Throwable
       case s: GetChatMemberCount              => sendRequest[R, GetChatMemberCount](s)
       case s: GetChatMembersCount             => sendRequest[R, GetChatMembersCount](s)
       case s: GetChatMenuButton               => sendRequest[R, GetChatMenuButton](s)
+      case s: GetCustomEmojiStickers          => sendRequest[R, GetCustomEmojiStickers](s)
       case s: GetFile                         => sendRequest[R, GetFile](s)
       case s: GetGameHighScores               => sendRequest[R, GetGameHighScores](s)
       case s: GetMe.type                      => sendRequest[R, GetMe.type](s)

--- a/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
@@ -14,6 +14,7 @@ import com.bot4s.telegram.models.MaskPositionType.MaskPositionType
 import com.bot4s.telegram.models.MemberStatus.MemberStatus
 import com.bot4s.telegram.models.BotCommandScope.BotCommandScope
 import com.bot4s.telegram.models.MessageEntityType.MessageEntityType
+import com.bot4s.telegram.models.StickerType.StickerType
 import UpdateType.UpdateType
 import com.bot4s.telegram.models._
 import io.circe.{ Decoder, HCursor }
@@ -43,6 +44,17 @@ trait CirceDecoders extends StrictLogging {
         case e: NoSuchElementException =>
           logger.warn(s"Unexpected MessageEntityType: '$s', fallback to Unknown.")
           MessageEntityType.Unknown
+      }
+    }
+
+  implicit val stickerTypeDecoder: Decoder[StickerType] =
+    Decoder[String].map { s =>
+      try {
+        StickerType.withName(pascalize(s))
+      } catch {
+        case e: NoSuchElementException =>
+          logger.warn(s"Unexpected StickerType: '$s', fallback to Unknown.")
+          StickerType.Unknown
       }
     }
 
@@ -88,6 +100,7 @@ trait CirceDecoders extends StrictLogging {
 
   implicit val KeyboardButtonPollTypeDecoder: Decoder[KeyboardButtonPollType] = deriveDecoder[KeyboardButtonPollType]
 
+  implicit val menuButtonDecoder: Decoder[MenuButton]                     = MenuButton.menuButtonDecoder
   implicit val contactDecoder: Decoder[Contact]                           = deriveDecoder[Contact]
   implicit val documentDecoder: Decoder[Document]                         = deriveDecoder[Document]
   implicit val fileDecoder: Decoder[File]                                 = deriveDecoder[File]

--- a/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
@@ -12,6 +12,7 @@ import com.bot4s.telegram.models.MaskPositionType.MaskPositionType
 import com.bot4s.telegram.models.MemberStatus.MemberStatus
 import com.bot4s.telegram.models.BotCommandScope.BotCommandScope
 import com.bot4s.telegram.models.MessageEntityType.MessageEntityType
+import com.bot4s.telegram.models.StickerType.StickerType
 import UpdateType.UpdateType
 import com.bot4s.telegram.models._
 import io.circe.Encoder
@@ -59,6 +60,9 @@ trait CirceEncoders {
 
   implicit val messageEntityTypeEncoder: Encoder[MessageEntityType] =
     Encoder[String].contramap[MessageEntityType](e => CaseConversions.snakenize(e.toString))
+
+  implicit val stickerTypeEncoder: Encoder[StickerType] =
+    Encoder[String].contramap[StickerType](e => CaseConversions.snakenize(e.toString))
 
   implicit val messageEntityEncoder: Encoder[MessageEntity] = deriveConfiguredEncoder[MessageEntity]
 
@@ -246,6 +250,8 @@ trait CirceEncoders {
   implicit val getUpdatesEncoder: Encoder[GetUpdates]         = deriveConfiguredEncoder[GetUpdates]
 
   implicit val chatLocationEncoder: Encoder[ChatLocation] = deriveConfiguredEncoder[ChatLocation]
+  // for v6.2 support
+  implicit val getCustomEmojiStickers: Encoder[GetCustomEmojiStickers] = deriveConfiguredEncoder[GetCustomEmojiStickers]
   // for v6.1 support
   implicit val createInvoiceLinkEncoder: Encoder[CreateInvoiceLink] = deriveConfiguredEncoder[CreateInvoiceLink]
   // for v6.0 support

--- a/core/src/com/bot4s/telegram/methods/CreateNewStickerSet.scala
+++ b/core/src/com/bot4s/telegram/methods/CreateNewStickerSet.scala
@@ -2,6 +2,7 @@ package com.bot4s.telegram.methods
 
 import com.bot4s.telegram.models.MaskPosition
 import com.bot4s.telegram.models.InputFile
+import com.bot4s.telegram.models.StickerType.StickerType
 
 /**
  * Use this method to create new sticker set owned by a user.
@@ -19,17 +20,19 @@ import com.bot4s.telegram.models.InputFile
  *                       [[https://core.telegram.org/stickers#animated-sticker-requirements for technical requirements]]
  * @param webmSticker    InputFile Optional WEBM video with the sticker, uploaded using multipart/form-data see
  *                       [[https://core.telegram.org/stickers#video-sticker-requirements for technical requirements]]
+ * @param stickerType    Optional StickerType. Type of stickers in the set, pass “regular” or “mask”. Custom emoji sticker sets can't be created via the Bot API at the moment. By default, a regular sticker set is created.
  * @param emojis	       String One or more emoji corresponding to the sticker
- * @param containsMasks  Boolean Optional Pass True, if a set of mask stickers should be created
+ * @param containsMasks  Boolean Optional Pass True, if a set of mask stickers should be created. Deprecated, use stickerType instead
  * @param maskPosition   MaskPosition Optional Position where the mask should be placed on faces
  */
 case class CreateNewStickerSet(
   userId: Long,
   name: String,
   title: String,
-  pngSticker: Option[InputFile],
-  tgsSticker: Option[InputFile],
-  webmSticker: Option[InputFile],
+  pngSticker: Option[InputFile] = None,
+  tgsSticker: Option[InputFile] = None,
+  webmSticker: Option[InputFile] = None,
+  stickerType: Option[StickerType] = None,
   emojis: String,
   containsMasks: Option[Boolean] = None,
   maskPosition: Option[MaskPosition] = None

--- a/core/src/com/bot4s/telegram/methods/GetCustomEmojiStickers.scala
+++ b/core/src/com/bot4s/telegram/methods/GetCustomEmojiStickers.scala
@@ -1,0 +1,11 @@
+package com.bot4s.telegram.methods
+
+import com.bot4s.telegram.models.Sticker
+
+/**
+ * Use this method to get information about custom emoji stickers by their identifiers.
+ * Returns an Array of Sticker objects.
+ *
+ * @param customEmojiIds     Array of string. List of custom emoji identifiers. At most 200 custom emoji identifiers can be specified
+ */
+case class GetCustomEmojiStickers(customEmojiIds: Array[String]) extends JsonRequest[List[Sticker]]

--- a/core/src/com/bot4s/telegram/models/Chat.scala
+++ b/core/src/com/bot4s/telegram/models/Chat.scala
@@ -18,21 +18,22 @@ import com.bot4s.telegram.models.ChatType.ChatType
  *                       Each administrator in a chat generates their own invite links, so the bot must first generate the link using exportChatInviteLink.
  *                       Returned only in getChat.
  *
- * @param pinnedMessage         Message Optional. Pinned message, for supergroups. Returned only in getChat.
- * @param permissions           ChatPermissions Optional. Default chat member permissions, for groups and supergroups. Returned only in getChat.
- * @param slowModeDelay         Integer Optional. For supergroups, the minimum allowed delay between consecutive messages sent by each unpriviledged user; in seconds. Returned only in getChat.
- * @param messageAutoDeleteTime Integer Optional. The time after which all messages sent to the chat will be automatically deleted; in seconds. Returned only in getChat.
- * @param stickerSetName        String Optional. For supergroups, name of group sticker set. Returned only in getChat.
- * @param canSetStickerSet      Boolean Optional. True, if the bot can change the group sticker set. Returned only in getChat.
- * @param linkedChatId          Long Optinal. Unique identifier for the linked chat, i.e. the discussion group identifier for a channel and vice versa; for supergroups and channel chats.
- *                              This identifier may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it.
- *                              But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier. Returned only in getChat.
- * @param location              Optional ChatLocation. For supergroups, the location to which the supergroup is connected. Returned only in getChat.
- * @param hasPrivateForwards    Boolean Optional. True, if privacy settings of the other party in the private chat allows to use tg://user?id=<user_id> links only in chats with the user.
- *                                Returned only in getChat.
- * @param hasProtectedContent   Boolean Optional. True, if messages from the chat can't be forwarded to other chats. Returned only in getChat.
- * @param joinToSendMessages    Boolean Optional. True, if users need to join the supergroup before they can send messages. Returned only in getChat.
- * @param joinByRequest         Boolean Optional. True, if all users directly joining the supergroup need to be approved by supergroup administrators. Returned only in getChat.
+ * @param pinnedMessage                       Message Optional. Pinned message, for supergroups. Returned only in getChat.
+ * @param permissions                         ChatPermissions Optional. Default chat member permissions, for groups and supergroups. Returned only in getChat.
+ * @param slowModeDelay                       Integer Optional. For supergroups, the minimum allowed delay between consecutive messages sent by each unpriviledged user; in seconds. Returned only in getChat.
+ * @param messageAutoDeleteTime               Integer Optional. The time after which all messages sent to the chat will be automatically deleted; in seconds. Returned only in getChat.
+ * @param stickerSetName                      String Optional. For supergroups, name of group sticker set. Returned only in getChat.
+ * @param canSetStickerSet                    Boolean Optional. True, if the bot can change the group sticker set. Returned only in getChat.
+ * @param linkedChatId                        Long Optinal. Unique identifier for the linked chat, i.e. the discussion group identifier for a channel and vice versa; for supergroups and channel chats.
+ *                                            This identifier may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it.
+ *                                            But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier. Returned only in getChat.
+ * @param location                            Optional ChatLocation. For supergroups, the location to which the supergroup is connected. Returned only in getChat.
+ * @param hasPrivateForwards                  Boolean Optional. True, if privacy settings of the other party in the private chat allows to use tg://user?id=<user_id> links only in chats with the user.
+ *                                              Returned only in getChat.
+ * @param hasProtectedContent                 Boolean Optional. True, if messages from the chat can't be forwarded to other chats. Returned only in getChat.
+ * @param joinToSendMessages                  Boolean Optional. True, if users need to join the supergroup before they can send messages. Returned only in getChat.
+ * @param joinByRequest                       Boolean Optional. True, if all users directly joining the supergroup need to be approved by supergroup administrators. Returned only in getChat.
+ * @param hasRestrictedVoiceAndVideoMessages 	Boolean Optional. True, if the privacy settings of the other party restrict sending voice and video note messages in the private chat. Returned only in getChat.
  */
 case class Chat(
   id: Long,
@@ -56,7 +57,8 @@ case class Chat(
   hasPrivateForwards: Option[Boolean] = None,
   hasProtectedContent: Option[Boolean] = None,
   joinToSendMessages: Option[Boolean] = None,
-  joinByRequest: Option[Boolean] = None
+  joinByRequest: Option[Boolean] = None,
+  hasRestrictedVoiceAndVideoMessages: Option[Boolean] = None
 ) {
   val chatId = ChatId(id)
 }

--- a/core/src/com/bot4s/telegram/models/MenuButton.scala
+++ b/core/src/com/bot4s/telegram/models/MenuButton.scala
@@ -49,7 +49,7 @@ object MenuButton {
   import io.circe.generic.extras.Configuration
   import com.bot4s.telegram.marshalling.CirceDecoders._
 
-  private implicit val configuration: Configuration = Configuration.default.withSnakeCaseMemberNames
+  private implicit val configuration: Configuration = Configuration.default
     .withDiscriminator("type")
     .copy(
       transformConstructorNames = {
@@ -59,6 +59,5 @@ object MenuButton {
       }
     )
 
-  implicit val menuButtonDecoder: Decoder[MenuButton] =
-    deriveConfiguredDecoder[MenuButton]
+  implicit val menuButtonDecoder: Decoder[MenuButton] = deriveConfiguredDecoder
 }

--- a/core/src/com/bot4s/telegram/models/MessageEntity.scala
+++ b/core/src/com/bot4s/telegram/models/MessageEntity.scala
@@ -7,19 +7,21 @@ import com.bot4s.telegram.models.MessageEntityType.MessageEntityType
  *
  * For example, hashtags, usernames, URLs, etc.
  *
- * @param type    String Type of the entity.
- *                One of mention (@username), hashtag, bot_command, url, email, bold (bold text), italic (italic text),
- *                code (monowidth string), pre (monowidth block), text_link (for clickable text URLs),
- *                text_mention (for users without usernames)
- * @param offset  Integer Offset in UTF-16 code units to the start of the entity
- * @param length  Integer Length of the entity in UTF-16 code units
- * @param url     String Optional For "text_link" only, url that will be opened after user taps on the text
- * @param user    User Optional. For "text_mention" only, the mentioned user
+ * @param type            String Type of the entity.
+ *                        One of mention (@username), hashtag, bot_command, url, email, bold (bold text), italic (italic text),
+ *                        code (monowidth string), pre (monowidth block), text_link (for clickable text URLs),
+ *                        text_mention (for users without usernames)
+ * @param offset          Integer Offset in UTF-16 code units to the start of the entity
+ * @param length          Integer Length of the entity in UTF-16 code units
+ * @param url             String Optional For "text_link" only, url that will be opened after user taps on the text
+ * @param user            User Optional. For "text_mention" only, the mentioned user
+ * @param customEmojiId 	String 	Optional. For “custom_emoji” only, unique identifier of the custom emoji. Use getCustomEmojiStickers to get full information about the sticker
  */
 case class MessageEntity(
   `type`: MessageEntityType,
   offset: Int,
   length: Int,
   url: Option[String] = None,
-  user: Option[User] = None
+  user: Option[User] = None,
+  customEmojiId: Option[String] = None
 )

--- a/core/src/com/bot4s/telegram/models/MessageEntityType.scala
+++ b/core/src/com/bot4s/telegram/models/MessageEntityType.scala
@@ -7,5 +7,5 @@ object MessageEntityType extends Enumeration {
   type MessageEntityType = Value
 
   val Bold, BotCommand, Cashtag, Code, Email, Spoiler, Hashtag, Italic, Mention, PhoneNumber, Pre, TextLink,
-    TextMention, Unknown, Url = Value
+    TextMention, Unknown, Url, CustomEmoji = Value
 }

--- a/core/src/com/bot4s/telegram/models/Sticker.scala
+++ b/core/src/com/bot4s/telegram/models/Sticker.scala
@@ -1,10 +1,14 @@
 package com.bot4s.telegram.models
 
+import com.bot4s.telegram.models.StickerType.StickerType
+
 /**
  * This object represents a sticker.
  *
  * @param fileId           Identifier for this file
  * @param fileUniqueId     Unique identifier for this file
+ * @param type             Type of the sticker, currently one of “regular”, “mask”, “custom_emoji”.
+ *                          The type of the sticker is independent from its format, which is determined by the fields is_animated and is_video.
  * @param width            Sticker width
  * @param height           Sticker height
  * @param isAnimated       Boolean True, if the sticker is animated
@@ -16,10 +20,12 @@ package com.bot4s.telegram.models
  *                         For mask stickers, the position where the mask should be placed
  * @param fileSize         Integer Optional. File size
  * @param premiumAnimation File Optional. Premium animation for the sticker, if the sticker is premium
+ * @param customEmojiId     String Optional. For custom emoji stickers, unique identifier of the custom emoji
  */
 case class Sticker(
   fileId: String,
   fileUniqueId: String,
+  `type`: StickerType,
   width: Int,
   height: Int,
   isAnimated: Boolean,
@@ -29,5 +35,6 @@ case class Sticker(
   setName: Option[String] = None,
   maskPosition: Option[MaskPosition] = None,
   fileSize: Option[Int] = None,
-  premiumAnimation: Option[File] = None
+  premiumAnimation: Option[File] = None,
+  customEmojiId: Option[String] = None
 )

--- a/core/src/com/bot4s/telegram/models/StickerSet.scala
+++ b/core/src/com/bot4s/telegram/models/StickerSet.scala
@@ -1,18 +1,22 @@
 package com.bot4s.telegram.models
 
+import com.bot4s.telegram.models.StickerType.StickerType
+
 /**
  * This object represents a sticker set.
  *
  * @param name           String Sticker set name
  * @param title          String Sticker set title
+ * @param stickerType    Type of stickers in the set
  * @param isAnimated     Boolean True, if the sticker set contains animated stickers
  * @param isVideo        Boolean True, if the sticker set contains video stickers
- * @param containsMasks  Boolean True, if the sticker set contains masks
+ * @param containsMasks  Boolean True, if the sticker set contains masks, deprecated, use stickerType instead
  * @param stickers       Array of Sticker List of all set stickers
  */
 case class StickerSet(
   name: String,
   title: String,
+  stickerType: StickerType,
   isAnimated: Boolean,
   isVideo: Boolean,
   containsMasks: Boolean,

--- a/core/src/com/bot4s/telegram/models/StickerType.scala
+++ b/core/src/com/bot4s/telegram/models/StickerType.scala
@@ -1,0 +1,10 @@
+package com.bot4s.telegram.models
+
+/**
+ * Different types of sticker
+ */
+object StickerType extends Enumeration {
+  type StickerType = Value
+
+  val Regular, Mask, CustomEmoji, Unknown = Value
+}

--- a/core/test/src/com/bot4s/telegram/marshalling/MarshallingSuite.scala
+++ b/core/test/src/com/bot4s/telegram/marshalling/MarshallingSuite.scala
@@ -5,6 +5,7 @@ import com.bot4s.telegram.models.CountryCode.CountryCode
 import com.bot4s.telegram.models.Currency.Currency
 import com.bot4s.telegram.models.MaskPositionType.MaskPositionType
 import com.bot4s.telegram.models.MessageEntityType.MessageEntityType
+import com.bot4s.telegram.models.StickerType.StickerType
 import com.bot4s.telegram.models.{ ChatId, MaskPositionType, _ }
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
@@ -128,7 +129,7 @@ class MarshallingSuite extends AnyFlatSpec with MockFactory with Matchers with T
     {
       "type": "default"
     }"""
-    io.circe.parser.decode[MenuButton](json).toOption.get shouldBe MenuButtonDefault(`type` = "default")
+    fromJson[MenuButton](json) shouldBe MenuButtonDefault(`type` = "default")
   }
 
   it should "decode a web app menu button" in {
@@ -140,7 +141,7 @@ class MarshallingSuite extends AnyFlatSpec with MockFactory with Matchers with T
         "url": "http://test.com"
       }
     }"""
-    io.circe.parser.decode[MenuButton](json).toOption.get shouldBe MenuButtonWebApp(
+    fromJson[MenuButton](json) shouldBe MenuButtonWebApp(
       `type` = "web_app",
       text = "Application",
       webApp = WebAppInfo(url = "http://test.com")
@@ -152,8 +153,20 @@ class MarshallingSuite extends AnyFlatSpec with MockFactory with Matchers with T
     {
       "type": "commands"
     }"""
-    io.circe.parser.decode[MenuButton](json).toOption.get shouldBe MenuButtonCommands(
+    fromJson[MenuButton](json) shouldBe MenuButtonCommands(
       `type` = "commands"
     )
+  }
+
+  it should "decode a sticker type" in {
+    fromJson[StickerType](""""regular"""") shouldBe StickerType.Regular
+    fromJson[StickerType](""""custom_emoji"""") shouldBe StickerType.CustomEmoji
+    fromJson[StickerType](""""mask"""") shouldBe StickerType.Mask
+  }
+
+  it should "encode a sticker type" in {
+    toJson[StickerType](StickerType.Regular) shouldBe """"regular""""
+    toJson[StickerType](StickerType.CustomEmoji) shouldBe """"custom_emoji""""
+    toJson[StickerType](StickerType.Mask) shouldBe """"mask""""
   }
 }


### PR DESCRIPTION
## Bot API 6.2 - August 12, 2022

### Custom Emoji Support

   - [x] Added the [MessageEntity](https://core.telegram.org/bots/api#messageentity) type “custom_emoji”.
   - [x] Added the field custom_emoji_id to the class [MessageEntity](https://core.telegram.org/bots/api#messageentity) for “custom_emoji” entities.
   - [x] Added the method [getCustomEmojiStickers](https://core.telegram.org/bots/api#getcustomemojistickers).
   - [x] Added the fields type and custom_emoji_id to the class [Sticker](https://core.telegram.org/bots/api#sticker).
   - [x] Added the field sticker_type to the class [StickerSet](https://core.telegram.org/bots/api#stickerset), describing the type of stickers in the set.
   - [x] The field contains_masks has been removed from the documentation of the class [StickerSet](https://core.telegram.org/bots/api#stickerset). The field is still returned in the object for backward compatibility, but new bots should use the field sticker_type instead.
   - [x] Added the parameter sticker_type to the method [createNewStickerSet](https://core.telegram.org/bots/api#createnewstickerset).
   - [x] The parameter contains_masks has been removed from the documentation of the method [createNewStickerSet](https://core.telegram.org/bots/api#createnewstickerset). The parameter will still work for backward compatibility, but new bots should use the parameter sticker_type instead.

### Other Changes

   - [x] Added the field has_restricted_voice_and_video_messages to the class [Chat](https://core.telegram.org/bots/api#chat) to support the [new setting](https://telegram.org/blog/custom-emoji#privacy-settings-for-voice-messages).