### PR TITLE
[api] Support v6.5

### DIFF
--- a/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
@@ -83,6 +83,14 @@ trait CirceDecoders extends StrictLogging {
   implicit val botCommandDecoder: Decoder[BotCommand] = deriveDecoder[BotCommand]
 
   implicit val chatLocationDecoder: Decoder[ChatLocation] = deriveDecoder[ChatLocation]
+  // for v6.5 support
+  implicit val KeyboardButtonRequestUserDecoder: Decoder[KeyboardButtonRequestUser] =
+    deriveDecoder[KeyboardButtonRequestUser]
+  implicit val KeyboardButtonRequestChatDecoder: Decoder[KeyboardButtonRequestChat] =
+    deriveDecoder[KeyboardButtonRequestChat]
+  implicit val UserSharedDecoder: Decoder[UserShared] = deriveDecoder[UserShared]
+  implicit val ChatSharedDecoder: Decoder[ChatShared] = deriveDecoder[ChatShared]
+
   // for v6.4 support
   implicit val editGeneralForumTopicDecoder: Decoder[EditGeneralForumTopic]     = deriveDecoder[EditGeneralForumTopic]
   implicit val closeGeneralForumTopicDecoder: Decoder[CloseGeneralForumTopic]   = deriveDecoder[CloseGeneralForumTopic]

--- a/core/src/com/bot4s/telegram/methods/RestrictChatMember.scala
+++ b/core/src/com/bot4s/telegram/methods/RestrictChatMember.scala
@@ -8,27 +8,18 @@ import com.bot4s.telegram.models.{ ChatId, ChatPermissions }
  * Pass True for all boolean parameters to lift restrictions from a user.
  * Returns True on success.
  *
- * @param chatId                 Integer or String	Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
- * @param userId                 Long	Yes	Unique identifier of the target user
- * @param permissions            ChatPermissions New user permissions
- * @param untilDate              Integer Optional Date when restrictions will be lifted for the user, unix time.
- *                               If user is restricted for more than 366 days or less than 30 seconds from the current time, they are considered to be restricted forever
- * @param canSendMessages        Boolean	Optional Pass True, if the user can send text messages, contacts, locations and venues
- * @param canSendMediaMessages   Boolean	Optional Pass True, if the user can send audios, documents, photos, videos, video notes and voice notes, implies can_send_messages
- * @param canSendOtherMessages   Boolean	Optional Pass True, if the user can send animations, games, stickers and use inline bots, implies can_send_media_messages
- * @param canAddWebPagePreviews  Boolean Optional Pass True, if the user may add web page previews to their messages, implies can_send_media_messages
+ * @param chatId                        Integer or String	Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+ * @param userId                        Long	Yes	Unique identifier of the target user
+ * @param permissions                   ChatPermissions New user permissions
+ * @param useIndependentChatPermissions Pass True if chat permissions are set independently.
+ *                                      Otherwise, the can_send_other_messages and can_add_web_page_previews permissions will imply the can_send_messages, can_send_audios, can_send_documents, can_send_photos, can_send_videos, can_send_video_notes, and can_send_voice_notes permissions; the can_send_polls permission will imply the can_send_messages permission.
+ * @param untilDate                     Integer Optional Date when restrictions will be lifted for the user, unix time.
+ *                                      If user is restricted for more than 366 days or less than 30 seconds from the current time, they are considered to be restricted forever
  */
 case class RestrictChatMember(
   chatId: ChatId,
   userId: Long,
   permissions: Option[ChatPermissions] = None,
-  untilDate: Option[Int] = None,
-  @Deprecated
-  canSendMessages: Option[Boolean] = None,
-  @Deprecated
-  canSendMediaMessages: Option[Boolean] = None,
-  @Deprecated
-  canSendOtherMessages: Option[Boolean] = None,
-  @Deprecated
-  canAddWebPagePreviews: Option[Boolean] = None
+  useIndependentChatPermissions: Option[Boolean] = None,
+  untilDate: Option[Int] = None
 ) extends JsonRequest[Boolean]

--- a/core/src/com/bot4s/telegram/methods/SetChatPermissions.scala
+++ b/core/src/com/bot4s/telegram/methods/SetChatPermissions.scala
@@ -9,5 +9,11 @@ import com.bot4s.telegram.models.{ ChatId, ChatPermissions }
  *
  * @param chatId      Integer or String Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @param permissions ChatPermissions New default chat permissions
+ * @param useIndependentChatPermissions Pass True if chat permissions are set independently.
+ *                                      Otherwise, the can_send_other_messages and can_add_web_page_previews permissions will imply the can_send_messages, can_send_audios, can_send_documents, can_send_photos, can_send_videos, can_send_video_notes, and can_send_voice_notes permissions; the can_send_polls permission will imply the can_send_messages permission.
  */
-case class SetChatPermissions(chatId: ChatId, permissions: ChatPermissions) extends JsonRequest[Boolean]
+case class SetChatPermissions(
+  chatId: ChatId,
+  permissions: ChatPermissions,
+  useIndependentChatPermissions: Option[Boolean] = None
+) extends JsonRequest[Boolean]

--- a/core/src/com/bot4s/telegram/models/ChatJoinRequest.scala
+++ b/core/src/com/bot4s/telegram/models/ChatJoinRequest.scala
@@ -5,6 +5,7 @@ package com.bot4s.telegram.models
  *
  * @param chat          Chat to which the request was sent
  * @param from          User that sent the join request
+ * @param userChatId    Identifier of a private chat with the user who sent the join request
  * @param date          Integer Date the request was sent in Unix time
  * @param bio           String Optional. Bio of the user.
  * @param inviteLink    ChatInviteLink Optional. Chat invite link that was used by the user to send the join request
@@ -13,6 +14,7 @@ package com.bot4s.telegram.models
 case class ChatJoinRequest(
   chat: Chat,
   from: User,
+  userChatId: Long,
   date: Int,
   bio: Option[String] = None,
   inviteLink: Option[ChatInviteLink] = None

--- a/core/src/com/bot4s/telegram/models/ChatMember.scala
+++ b/core/src/com/bot4s/telegram/models/ChatMember.scala
@@ -19,7 +19,12 @@ import MemberStatus.MemberStatus
  * @param canPromoteMembers      Boolean Optional. Administrators only. True, if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user)
  * @param isMember               Boolean Optional. Restricted only. True, if the user is a member of the chat at the moment of the request
  * @param canSendMessages        Boolean Optional. Restricted only. True, if the user can send text messages, contacts, locations and venues
- * @param canSendMediaMessages   Boolean Optional. Restricted only. True, if the user can send audios, documents, photos, videos, video notes and voice notes, implies can_send_messages
+ * @param canSendAudios,         Boolean Optional. True, if the user is allowed to send audios
+ * @param canSendDocuments       Boolean Optional. True, if the user is allowed to send documents
+ * @param canSendPhotos          Boolean Optional. True, if the user is allowed to send photos
+ * @param canSendVideos          Boolean Optional. True, if the user is allowed to send videos
+ * @param canSendVideoNotes      Boolean Optional. True, if the user is allowed to send video notes
+ * @param canSendVoiceNotes      Boolean Optional. True, if the user is allowed to send voice notes
  * @param canSendPolls           Boolean Optional. Restricted only. True, if the user is allowed to send polls
  * @param canSendOtherMessages   Boolean Optional. Restricted only. True, if the user can send animations, games, stickers and use inline bots, implies can_send_media_messages
  * @param canAddWebPagePreviews  Boolean Optional. Restricted only. True, if user may add web page previews to his messages, implies can_send_media_messages
@@ -41,7 +46,12 @@ case class ChatMember(
   canPromoteMembers: Option[Boolean] = None,
   isMember: Option[Boolean] = None,
   canSendMessages: Option[Boolean] = None,
-  canSendMediaMessages: Option[Boolean] = None,
+  canSendAudios: Option[Boolean] = None,
+  canSendDocuments: Option[Boolean] = None,
+  canSendPhotos: Option[Boolean] = None,
+  canSendVideos: Option[Boolean] = None,
+  canSendVideoNotes: Option[Boolean] = None,
+  canSendVoiceNotes: Option[Boolean] = None,
   canSendPolls: Option[Boolean] = None,
   canSendOtherMessages: Option[Boolean] = None,
   canAddWebPagePreviews: Option[Boolean] = None,

--- a/core/src/com/bot4s/telegram/models/ChatPermissions.scala
+++ b/core/src/com/bot4s/telegram/models/ChatPermissions.scala
@@ -4,7 +4,12 @@ package com.bot4s.telegram.models
  * Describes actions that a non-administrator user is allowed to take in a chat.
  *
  * @param canSendMessages        Boolean Optional. True, if the user is allowed to send text messages, contacts, locations and venues
- * @param canSendMediaMessages   Boolean Optional. True, if the user is allowed to send audios, documents, photos, videos, video notes and voice notes, implies can_send_messages
+ * @param canSendAudios,         Boolean Optional. True, if the user is allowed to send audios
+ * @param canSendDocuments       Boolean Optional. True, if the user is allowed to send documents
+ * @param canSendPhotos          Boolean Optional. True, if the user is allowed to send photos
+ * @param canSendVideos          Boolean Optional. True, if the user is allowed to send videos
+ * @param canSendVideoNotes      Boolean Optional. True, if the user is allowed to send video notes
+ * @param canSendVoiceNotes      Boolean Optional. True, if the user is allowed to send voice notes
  * @param canSendPolls           Boolean Optional. True, if the user is allowed to send polls, implies can_send_messages
  * @param canSendOtherMessages   Boolean Optional. True, if the user is allowed to send animations, games, stickers and use inline bots, implies can_send_media_messages
  * @param canAddWebPagePreviews  Boolean Optional. True, if the user is allowed to add web page previews to their messages, implies can_send_media_messages
@@ -15,7 +20,12 @@ package com.bot4s.telegram.models
  */
 case class ChatPermissions(
   canSendMessages: Option[Boolean] = None,
-  canSendMediaMessages: Option[Boolean] = None,
+  canSendAudios: Option[Boolean] = None,
+  canSendDocuments: Option[Boolean] = None,
+  canSendPhotos: Option[Boolean] = None,
+  canSendVideos: Option[Boolean] = None,
+  canSendVideoNotes: Option[Boolean] = None,
+  canSendVoiceNotes: Option[Boolean] = None,
   canSendPolls: Option[Boolean] = None,
   canSendOtherMessages: Option[Boolean] = None,
   canAddWebPagePreviews: Option[Boolean] = None,

--- a/core/src/com/bot4s/telegram/models/ChatShared.scala
+++ b/core/src/com/bot4s/telegram/models/ChatShared.scala
@@ -1,0 +1,9 @@
+package com.bot4s.telegram.models
+
+/**
+ * This object contains information about the chat whose identifier was shared with the bot using a KeyboardButtonRequestChat button.
+ *
+ * @param requestId Identifier of the request
+ * @param chatId  	Identifier of the shared chat. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier. The bot may not have access to the chat and could be unable to use this identifier, unless the chat is already known to the bot by some other means.
+ */
+case class ChatShared(requestId: Int, chatId: Long)

--- a/core/src/com/bot4s/telegram/models/Message.scala
+++ b/core/src/com/bot4s/telegram/models/Message.scala
@@ -120,6 +120,8 @@ case class Message(
   pinnedMessage: Option[Message] = None,
   invoice: Option[Invoice] = None,
   successfulPayment: Option[SuccessfulPayment] = None,
+  userShared: Option[UserShared] = None,
+  chatShared: Option[ChatShared] = None,
   connectedWebsite: Option[String] = None,
   replyMarkup: Option[InlineKeyboardMarkup] = None,
   hasProtectedContent: Option[Boolean] = None,

--- a/core/src/com/bot4s/telegram/models/ReplyMarkup.scala
+++ b/core/src/com/bot4s/telegram/models/ReplyMarkup.scala
@@ -29,6 +29,8 @@ sealed trait ReplyMarkup
  */
 case class KeyboardButton(
   text: String,
+  requestUser: Option[KeyboardButtonRequestUser] = None,
+  requestChat: Option[KeyboardButtonRequestChat] = None,
   requestContact: Option[Boolean] = None,
   requestLocation: Option[Boolean] = None,
   requestPoll: Option[KeyboardButtonPollType] = None,
@@ -351,4 +353,41 @@ case class ForceReply(
  */
 case class KeyboardButtonPollType(
   `type`: Option[String] = None
+)
+
+/**
+ * This object defines the criteria used to request a suitable user.
+ * The identifier of the selected user will be shared with the bot when the corresponding button is pressed
+ *
+ * @param requestId Signed 32-bit identifier of the request, which will be received back in the UserShared object. Must be unique within the message
+ * @param userIsBot  Pass True to request a bot, pass False to request a regular user. If not specified, no additional restrictions are applied.
+ * @param userIsPremium // Pass True to request a premium user, pass False to request a non-premium user. If not specified, no additional restrictions are applied.
+ */
+case class KeyboardButtonRequestUser(
+  requestId: Int,
+  userIsBot: Option[Boolean] = None,
+  userIsPremium: Option[Boolean] = None
+)
+
+/**
+ * This object defines the criteria used to request a suitable chat. The identifier of the selected chat will be shared with the bot when the corresponding button is pressed
+ *
+ * @param requestId Signed 32-bit identifier of the request, which will be received back in the ChatShared object. Must be unique within the message
+ * @param chatIsChannel Pass True to request a channel chat, pass False to request a group or a supergroup chat.
+ * @param chatIsForum Pass True to request a forum supergroup, pass False to request a non-forum chat. If not specified, no additional restrictions are applied.
+ * @param chatHasUserName Pass True to request a supergroup or a channel with a username, pass False to request a chat without a username. If not specified, no additional restrictions are applied.
+ * @param chatIsCreated  Pass True to request a chat owned by the user. Otherwise, no additional restrictions are applied.
+ * @param userAdministratorRights  Pass True to request a chat owned by the user. Otherwise, no additional restrictions are applied.
+ * @param botAdministratorRights  Pass True to request a chat owned by the user. Otherwise, no additional restrictions are applied.
+ * @param botIsMember Pass True to request a chat with the bot as a member. Otherwise, no additional restrictions are applied.
+ */
+case class KeyboardButtonRequestChat(
+  requestId: Int,
+  chatIsChannel: Boolean,
+  chatIsForum: Option[Boolean] = None,
+  chatHasUserName: Option[Boolean] = None,
+  chatIsCreated: Option[Boolean] = None,
+  userAdministratorRights: Option[ChatAdministratorRights] = None,
+  botAdministratorRights: Option[ChatAdministratorRights] = None,
+  botIsMember: Option[Boolean] = None
 )

--- a/core/src/com/bot4s/telegram/models/UserShared.scala
+++ b/core/src/com/bot4s/telegram/models/UserShared.scala
@@ -1,0 +1,9 @@
+package com.bot4s.telegram.models
+
+/**
+ * This object contains information about the user whose identifier was shared with the bot using a KeyboardButtonRequestUser button.
+ *
+ * @param requestId Identifier of the request
+ * @param userId Identifier of the shared user. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier. The bot may not have access to the user and could be unable to use this identifier, unless the user is already known to the bot by some other means.
+ */
+case class UserShared(requestId: Int, userId: Long)


### PR DESCRIPTION
- [x] Added the class KeyboardButtonRequestUser and the field request_user to the class KeyboardButton.
- [x] Added the class KeyboardButtonRequestChat and the field request_chat to the class KeyboardButton.
- [x] Added the classes UserShared, ChatShared and the fields user_shared, and chat_shared to the class Message.
- [x] Replaced the fields can_send_media_messages in the classes ChatMemberRestricted and ChatPermissions with separate fields can_send_audios, can_send_documents, can_send_photos, can_send_videos, can_send_video_notes, and can_send_voice_notes for different media types.
- [x] Added the parameter use_independent_chat_permissions to the methods restrictChatMember and setChatPermissions.
- [x] Added the field user_chat_id to the class ChatJoinRequest.

https://core.telegram.org/bots/api#february-3-2023