### PR TITLE
Support API 6.8 and 6.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://core.telegram.org/bots/api#recent-changes" title="Telegram Bot API">
-    <img src="https://img.shields.io/badge/Bot%20API-6.7%20(April%2021,%202023)-00aced.svg"/>
+    <img src="https://img.shields.io/badge/Bot%20API-6.9%20(September%2022,%202023)-00aced.svg"/>
   </a>
   <a href="https://t.me/bot4s_updates" title="Bot4s Telegram Channel">
     <img src="https://img.shields.io/badge/💬%20Channel-Bot4s-00aced.svg"/>
@@ -67,17 +67,17 @@ Add to your `build.sbt` file:
 
 ```scala
 // Core with minimal dependencies, enough to spawn your first bot.
-libraryDependencies += "com.bot4s" %% "telegram-core" % "5.7.0"
+libraryDependencies += "com.bot4s" %% "telegram-core" % "5.7.1"
 
 // Extra goodies: Webhooks, support for games, bindings for actors.
-libraryDependencies += "com.bot4s" %% "telegram-akka" % "5.7.0"
+libraryDependencies += "com.bot4s" %% "telegram-akka" % "5.7.1"
 ```
 
 For [mill](https://com-lihaoyi.github.io/mill) add to your `build.sc` project deps:
 
 ```scala
-ivy"com.bot4s::telegram-core:5.7.0", // core
-ivy"com.bot4s::telegram-akka:5.7.0"  // extra goodies
+ivy"com.bot4s::telegram-core:5.7.1", // core
+ivy"com.bot4s::telegram-akka:5.7.1"  // extra goodies
 ```
 
 ## Leaking bot tokens

--- a/build.sc
+++ b/build.sc
@@ -133,7 +133,7 @@ trait Bot4sTelegramCrossPlatform extends Bot4sTelegramModule {
 
 trait Publishable extends PublishModule {
 
-  override def publishVersion = "5.7.0"
+  override def publishVersion = "5.7.1"
 
   def pomSettings = PomSettings(
     description = "Telegram Bot API wrapper for Scala",

--- a/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceDecoders.scala
@@ -189,6 +189,7 @@ trait CirceDecoders extends StrictLogging {
   implicit val userProfilePhotosDecoder: Decoder[UserProfilePhotos] = deriveDecoder[UserProfilePhotos]
   implicit val venueDecoder: Decoder[Venue]                         = deriveDecoder[Venue]
   implicit val videoDecoder: Decoder[Video]                         = deriveDecoder[Video]
+  implicit val storyDecoder: Decoder[Story.type]                    = deriveDecoder[Story.type]
   implicit val videoNoteDecoder: Decoder[VideoNote]                 = deriveDecoder[VideoNote]
   implicit val voiceDecoder: Decoder[Voice]                         = deriveDecoder[Voice]
   implicit val videoChatEndedDecoder: Decoder[VideoChatEnded]       = deriveDecoder[VideoChatEnded]

--- a/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
+++ b/core/src/com/bot4s/telegram/marshalling/CirceEncoders.scala
@@ -98,6 +98,8 @@ trait CirceEncoders {
   implicit val videoNoteEncoder: Encoder[VideoNote]                 = deriveConfiguredEncoder[VideoNote]
   implicit val voiceEncoder: Encoder[Voice]                         = deriveConfiguredEncoder[Voice]
 
+  implicit val storyEncoder: Encoder[Story.type] = deriveConfiguredEncoder[Story.type]
+
   implicit val loginUrlEncoder: Encoder[LoginUrl] = deriveConfiguredEncoder[LoginUrl]
 
   // Payments
@@ -251,6 +253,9 @@ trait CirceEncoders {
   implicit val getUpdatesEncoder: Encoder[GetUpdates]         = deriveConfiguredEncoder[GetUpdates]
 
   implicit val chatLocationEncoder: Encoder[ChatLocation] = deriveConfiguredEncoder[ChatLocation]
+  // for v6.8 support
+  implicit val unpinAllGeneralForumTopicMessagesEncoder: Encoder[UnpinAllGeneralForumTopicMessages] =
+    deriveConfiguredEncoder[UnpinAllGeneralForumTopicMessages]
   // for v6.7 support
   implicit val getMyNameEncoder: Encoder[GetMyName] = deriveConfiguredEncoder[GetMyName]
   implicit val setMyNameEncoder: Encoder[SetMyName] = deriveConfiguredEncoder[SetMyName]

--- a/core/src/com/bot4s/telegram/methods/PromoteChatMember.scala
+++ b/core/src/com/bot4s/telegram/methods/PromoteChatMember.scala
@@ -23,6 +23,9 @@ import com.bot4s.telegram.models.ChatId
  * @param canManageVideoChats Boolean Optional Pass True, if the administrator can manage video chats
  * @param canRestrictMembers  Boolean Optional Pass True, if the administrator can restrict, ban or unban chat members
  * @param canPinMessages      Boolean Optional Pass True, if the administrator can pin messages, supergroups only
+ * @param canPostStories      Boolean Optional Pass True, if the administrator can post stories in the channel, channels only
+ * @param canEditStories      Boolean Optional Pass True, if the administrator can post stories in the channel, channels only
+ * @param canDeleteStories    Boolean Optional Pass True, if the administrator can post stories in the channel, channels only
  * @param canPromoteMembers   Boolean Optional Pass True, if the administrator can add new administrators with a subset
  *                            of his own privileges or demote administrators that he has promoted,
  *                            directly or indirectly (promoted by administrators that were appointed by him)
@@ -41,6 +44,9 @@ case class PromoteChatMember(
   canManageVideoChats: Option[Boolean] = None,
   canRestrictMembers: Option[Boolean] = None,
   canPinMessages: Option[Boolean] = None,
+  canPostStories: Option[Boolean] = None,
+  canEditStories: Option[Boolean] = None,
+  canDeleteStories: Option[Boolean] = None,
   canPromoteMembers: Option[Boolean] = None,
   canManageTopics: Option[Boolean]
 ) extends JsonRequest[Boolean]

--- a/core/src/com/bot4s/telegram/methods/UnpinAllGeneralForumTopicMessages.scala
+++ b/core/src/com/bot4s/telegram/methods/UnpinAllGeneralForumTopicMessages.scala
@@ -1,0 +1,13 @@
+package com.bot4s.telegram.methods
+
+import com.bot4s.telegram.models.ChatId
+
+/**
+ * Use this method to clear the list of pinned messages in a General forum topic.
+ *
+ * he bot must be an administrator in the chat for this to work and must have the can_pin_messages administrator right in the supergroup.
+ * Returns True on success.
+ *
+ * @param chatId   ChatId  	Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+ */
+case class UnpinAllGeneralForumTopicMessages(chatId: ChatId) extends JsonRequest[Boolean]

--- a/core/src/com/bot4s/telegram/models/Chat.scala
+++ b/core/src/com/bot4s/telegram/models/Chat.scala
@@ -37,6 +37,7 @@ import com.bot4s.telegram.models.ChatType.ChatType
  * @param isForum                             Boolean Optional. True, if the supergroup chat is a forum (has topics enabled)
  * @param activeUsernames                     Array of string Optional. If non-empty, the list of all active chat usernames; for private chats, supergroups and channels. Returned only in getChat.
  * @param emojiStatusCustomEmojiId            String Optional. Custom emoji identifier of emoji status of the other party in a private chat. Returned only in getChat.
+ * @param emojiStatusExpirationDate           Integer Optional. Expiration date of the emoji status of the other party in a private chat in Unix time, if any. Returned only in getChat.
  * @param hasHiddenMembers                    Boolean Optional. True, if non-administrators can only get the list of bots and administrators in the chat. Returned only in getChat
  * @param hasAggressiveAntiSpamEnabled        Boolean Optional. True, if the aggressive anti-spam checks are enabled in the supergroup. The field is only available to chat administrators. Returned only in getChat
  */
@@ -67,6 +68,7 @@ case class Chat(
   isForum: Option[Boolean] = None,
   activeUsernames: Option[List[String]] = None,
   emojiStatusCustomEmojiId: Option[String] = None,
+  emojiStatusExpirationDate: Option[Long] = None,
   hasHiddenMembers: Option[Boolean] = None,
   hasAggressiveAntiSpamEnabled: Option[Boolean] = None
 ) {

--- a/core/src/com/bot4s/telegram/models/ChatMember.scala
+++ b/core/src/com/bot4s/telegram/models/ChatMember.scala
@@ -16,6 +16,9 @@ import MemberStatus.MemberStatus
  * @param canInviteUsers         Boolean Optional. Administrators and restricted only. True, if the user is allowed to invite new users to the chat
  * @param canRestrictMembers     Boolean Optional. Administrators only. True, if the administrator can restrict, ban or unban chat members
  * @param canPinMessages         Boolean Optional. Administrators and restricted only. True, if the user is allowed to pin messages; groups and supergroups only
+ * @param canPostStories         Boolean Optional. True, if the administrator can post stories in the channel; channels only
+ * @param canEditStories         Boolean Optional. True, if the administrator can edit stories in the channel; channels only
+ * @param canDeleteStories       Boolean Optional. True, if the administrator can delete stories in the channel; channels only
  * @param canPromoteMembers      Boolean Optional. Administrators only. True, if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user)
  * @param isMember               Boolean Optional. Restricted only. True, if the user is a member of the chat at the moment of the request
  * @param canSendMessages        Boolean Optional. Restricted only. True, if the user can send text messages, contacts, locations and venues
@@ -43,6 +46,9 @@ case class ChatMember(
   canInviteUsers: Option[Boolean] = None,
   canRestrictMembers: Option[Boolean] = None,
   canPinMessages: Option[Boolean] = None,
+  canPostStories: Option[Boolean] = None,
+  canEditStories: Option[Boolean] = None,
+  canDeleteStories: Option[Boolean] = None,
   canPromoteMembers: Option[Boolean] = None,
   isMember: Option[Boolean] = None,
   canSendMessages: Option[Boolean] = None,

--- a/core/src/com/bot4s/telegram/models/Message.scala
+++ b/core/src/com/bot4s/telegram/models/Message.scala
@@ -31,6 +31,7 @@ package com.bot4s.telegram.models
  *                                    [[https://core.telegram.org/bots/api#games More about games »]]
  * @param photo                       Optional Message is a photo, available sizes of the photo
  * @param sticker                     Optional Message is a sticker, information about the sticker
+ * @param story                       Optional Message is a forwarded story
  * @param video                       Optional Message is a video, information about the video
  * @param voice                       Optional Message is a voice message, information about the file
  * @param videoNote                   Optional Message is a video note, information about the video message
@@ -99,6 +100,7 @@ case class Message(
   game: Option[Game] = None,
   photo: Option[Seq[PhotoSize]] = None,
   sticker: Option[Sticker] = None,
+  story: Option[Story.type] = None,
   video: Option[Video] = None,
   voice: Option[Voice] = None,
   videoNote: Option[VideoNote] = None,

--- a/core/src/com/bot4s/telegram/models/Story.scala
+++ b/core/src/com/bot4s/telegram/models/Story.scala
@@ -1,0 +1,6 @@
+package com.bot4s.telegram.models
+
+/**
+ * This object represents a message about a forwarded story in the chat. Currently holds no information.
+ */
+case object Story

--- a/core/src/com/bot4s/telegram/models/WriteAccessAllowed.scala
+++ b/core/src/com/bot4s/telegram/models/WriteAccessAllowed.scala
@@ -1,9 +1,13 @@
 package com.bot4s.telegram.models
 
 /**
- * This object represents a service message about a user allowing a bot added to the attachment menu to write messages. Currently holds no information.
- * @param webAppName  Name of the Web App which was launched from a link
+ * This object represents a service message about a user allowing a bot added to the attachment menu to write messages.
+ * @param fromRequest         True, if the access was granted after the user accepted an explicit request from a Web App sent by the method requestWriteAccess
+ * @param webAppName          Name of the Web App which was launched from a link
+ * @param fromAttachmentMenu  True, if the access was granted when the bot was added to the attachment or side menu
  */
 case class WriteAccessAllowed(
-  webAppName: Option[String] = None
+  fromRequest: Option[Boolean] = None,
+  webAppName: Option[String] = None,
+  fromAttachmentMenu: Option[Boolean] = None
 )


### PR DESCRIPTION
Bot API 6.9

- [x]  Added the new administrator privileges can_post_stories, can_edit_stories and can_delete_stories to the classes [ChatMemberAdministrator](https://core.telegram.org/bots/api#chatmemberadministrator) and [ChatAdministratorRights](https://core.telegram.org/bots/api#chatadministratorrights).
- [x]   Added the parameters can_post_stories, can_edit_stories and can_delete_stories to the method [promoteChatMember](https://core.telegram.org/bots/api#promotechatmember). Currently, bots have no use for these privileges besides assigning them to other administrators.
- [x]   Added the fields from_request and from_attachment_menu to the class [WriteAccessAllowed](https://core.telegram.org/bots/api#writeaccessallowed).

Bot API 6.8

- [x] Added the field story to the class [Message](https://core.telegram.org/bots/api#message) for messages with forwarded stories. Currently, it holds no information.
- [x] Added the field emoji_status_expiration_date to the class [Chat](https://core.telegram.org/bots/api#chat).
- [x] Added the method [unpinAllGeneralForumTopicMessages](https://core.telegram.org/bots/api#unpinallgeneralforumtopicmessages).

Notes: polls are missing from this bot, I will add them in the future, they were added a long time ago in 4.6 https://core.telegram.org/bots/api-changelog#january-23-2020