### PR TITLE
change sendRequestInternal from private to protected

### DIFF
--- a/core/src/com/bot4s/telegram/api/RequestHandler.scala
+++ b/core/src/com/bot4s/telegram/api/RequestHandler.scala
@@ -41,7 +41,7 @@ abstract class RequestHandler[F[_]](implicit monadError: MonadError[F, Throwable
                   .rethrow
     } yield result
 
-  private def sendRequestInternal[R](request: Request[R]): F[R] =
+  protected def sendRequestInternal[R](request: Request[R]): F[R] =
     request match {
       // Pure JSON requests
       case s: ApproveChatJoinRequest            => sendRequest[R, ApproveChatJoinRequest](s)


### PR DESCRIPTION
This PR provide a change of sendRequestInternal method from private to protected for opportunity to override apply method without copying of sendRequestInternal method.